### PR TITLE
refactor: use class for metadata

### DIFF
--- a/packages/express-cargo/src/binding.ts
+++ b/packages/express-cargo/src/binding.ts
@@ -1,65 +1,63 @@
 import type { Request, RequestHandler } from 'express'
 
-import { CargoFieldError, CargoFieldMetadata, CargoValidationError } from './types'
-import { getFieldMetadata, getFieldList } from './metadata'
+import { CargoFieldError, CargoValidationError } from './types'
+import { CargoClassMetadata, CargoFieldMetadata } from './metadata'
 
 export function bindingCargo<T extends object = any>(cargoClass: new () => T): RequestHandler {
     return (req, res, next) => {
         try {
             const cargo = new cargoClass() as any
-            const prototype = cargoClass.prototype
+            const classMeta = new CargoClassMetadata(cargoClass.prototype)
             const errors: CargoFieldError[] = []
 
-            const fields = getFieldList(prototype)
+            const fields = classMeta.getFieldList()
             for (const property of fields) {
-                const meta: CargoFieldMetadata = getFieldMetadata(prototype, property)
+                const meta: CargoFieldMetadata = classMeta.getFieldMetadata(property)
                 if (!meta) continue
 
-                if (meta.source) {
-                    let value
-                    const key = typeof meta.key === 'string' ? meta.key : meta.key.description
+                let value
+                const key = typeof meta.key === 'string' ? meta.key : meta.key.description
 
-                    if (!key) {
-                        errors.push(new CargoFieldError(key!, 'empty string or symbol is not allowed'))
-                        continue
-                    }
-
-                    switch (meta.source) {
-                        case 'body':
-                            value = req.body?.[key]
-                            break
-                        case 'query':
-                            value = req.query?.[key]
-                            break
-                        case 'uri':
-                            value = req.params?.[key]
-                            break
-                        case 'header':
-                            value = req.headers?.[String(key).toLowerCase()]
-                            break
-                        case 'session':
-                            value = (req as any).session?.[key]
-                            break
-                    }
-
-                    if (value === undefined || value === null) {
-                        if (meta.optional) {
-                            cargo[property] = undefined;
-                            continue; 
-                        } else {
-                            errors.push(new CargoFieldError(key, `${key} is required`));
-                            continue; 
-                        }
-                    }
-
-                    for (const rule of meta.validators) {
-                        if (!rule.validate(value)) {
-                            errors.push(new CargoFieldError(key, rule.message))
-                        }
-                    }
-
-                    cargo[property] = value
+                if (!key) {
+                    errors.push(new CargoFieldError(key!, 'empty string or symbol is not allowed'))
+                    continue
                 }
+
+                switch (meta.getSource()) {
+                    case 'body':
+                        value = req.body?.[key]
+                        break
+                    case 'query':
+                        value = req.query?.[key]
+                        break
+                    case 'uri':
+                        value = req.params?.[key]
+                        break
+                    case 'header':
+                        value = req.headers?.[String(key).toLowerCase()]
+                        break
+                    case 'session':
+                        value = (req as any).session?.[key]
+                        break
+                }
+
+                if (value === undefined || value === null) {
+                    if (meta.getOptional()) {
+                        cargo[property] = undefined;
+                        continue;
+                    } else {
+                        errors.push(new CargoFieldError(key, `${key} is required`));
+                        continue;
+                    }
+                }
+
+                for (const rule of meta.getValidators()) {
+                    if (!rule.validate(value)) {
+                        errors.push(new CargoFieldError(key, rule.message))
+                    }
+                }
+
+                cargo[property] = value
             }
 
             if (errors.length > 0) {

--- a/packages/express-cargo/src/decorators.ts
+++ b/packages/express-cargo/src/decorators.ts
@@ -1,9 +1,10 @@
-import { getFieldMetadata, setFieldMetadata } from './metadata'
+import { CargoClassMetadata } from './metadata'
 
 export function optional(): PropertyDecorator {
-    return (target: any, propertyKey: string | symbol) => { 
-     const meta = getFieldMetadata(target, propertyKey);
-     meta.optional = true;
-     setFieldMetadata(target, propertyKey, meta);
-  };
+    return (target: any, propertyKey: string | symbol) => {
+        const classMeta = new CargoClassMetadata(target)
+        const fieldMeta = classMeta.getFieldMetadata(propertyKey)
+        fieldMeta.setOptional(true)
+        classMeta.setFieldMetadata(propertyKey, fieldMeta)
+    }
 }

--- a/packages/express-cargo/src/source.ts
+++ b/packages/express-cargo/src/source.ts
@@ -1,14 +1,14 @@
 import { Source } from './types'
-import { setFieldList, getFieldMetadata, setFieldMetadata } from './metadata'
+import { CargoClassMetadata } from './metadata'
 
 function createSourceDecorator(source: Source) {
     return (key?: string): PropertyDecorator => {
         return (target, propertyKey) => {
-            const meta = getFieldMetadata(target, propertyKey)
-            meta.source = source
-            meta.key = key ?? propertyKey
-            setFieldMetadata(target, propertyKey, meta)
-            setFieldList(target, propertyKey)
+            const classMeta = new CargoClassMetadata(target)
+            const fieldMeta = classMeta.getFieldMetadata(key ?? propertyKey)
+            fieldMeta.setSource(source)
+            classMeta.setFieldMetadata(propertyKey, fieldMeta)
+            classMeta.setFieldList(propertyKey)
         }
     }
 }

--- a/packages/express-cargo/src/types.ts
+++ b/packages/express-cargo/src/types.ts
@@ -1,12 +1,5 @@
 export type Source = 'body' | 'query' | 'uri' | 'header' | 'session'
 
-export type CargoFieldMetadata = {
-    key: string | symbol
-    source: Source
-    validators: ValidatorRule[]
-    optional?: boolean
-}
-
 type ValidatorFunction = (value: any) => boolean
 export type ValidatorRule = {
     type: string

--- a/packages/express-cargo/src/validator.ts
+++ b/packages/express-cargo/src/validator.ts
@@ -1,11 +1,11 @@
 import { ValidatorRule } from './types'
-import { getFieldMetadata, setFieldMetadata } from './metadata'
+import { CargoClassMetadata } from './metadata'
 
 function addValidator(target: any, propertyKey: string | symbol, rule: ValidatorRule) {
-    const meta = getFieldMetadata(target, propertyKey)
-    meta.validators = meta.validators || []
-    meta.validators.push(rule)
-    setFieldMetadata(target, propertyKey, meta)
+    const classMeta = new CargoClassMetadata(target)
+    const fieldMeta = classMeta.getFieldMetadata(propertyKey)
+    fieldMeta.addValidator(rule)
+    classMeta.setFieldMetadata(propertyKey, fieldMeta)
 }
 
 export function min(minimum: number): PropertyDecorator {

--- a/packages/express-cargo/tests/decorator/optional.test.ts
+++ b/packages/express-cargo/tests/decorator/optional.test.ts
@@ -1,5 +1,5 @@
 import { optional } from '../../src/decorators'
-import { getFieldMetadata } from '../../src/metadata'
+import { CargoClassMetadata } from '../../src/metadata'
 
 describe('optional decorator', () => {
     class Sample {
@@ -9,13 +9,15 @@ describe('optional decorator', () => {
         field2?: number
     }
 
-     it('should mark field1 as optional in metadata', () => {
-        const meta = getFieldMetadata(Sample.prototype, 'field1')
-        expect(meta.optional).toBe(true)
+    const classMeta = new CargoClassMetadata(Sample.prototype)
+
+    it('should mark field1 as optional in metadata', () => {
+        const meta = classMeta.getFieldMetadata('field1')
+        expect(meta.getOptional()).toBe(true)
     })
 
     it('should not mark field2 as optional in metadata', () => {
-        const meta = getFieldMetadata(Sample.prototype, 'field2')
-        expect(meta.optional).toBeUndefined()
+        const meta = classMeta.getFieldMetadata('field2')
+        expect(meta.getOptional()).toBe(false)
     })
 })

--- a/packages/express-cargo/tests/validator/equal.test.ts
+++ b/packages/express-cargo/tests/validator/equal.test.ts
@@ -1,5 +1,5 @@
 import { equal } from '../../src/validator'
-import { getFieldMetadata } from '../../src/metadata'
+import { CargoClassMetadata } from '../../src/metadata'
 
 describe('equal decorator', () => {
     class Sample {
@@ -18,9 +18,11 @@ describe('equal decorator', () => {
         undefinedValue!: undefined
     }
 
+    const classMeta = new CargoClassMetadata(Sample.prototype)
+
     it('should have equal validator with string argument', () => {
-        const meta = getFieldMetadata(Sample.prototype, 'role')
-        const equalRule = meta.validators?.find(v => v.type === 'equal')
+        const meta = classMeta.getFieldMetadata('role')
+        const equalRule = meta.getValidators()?.find(v => v.type === 'equal')
 
         expect(equalRule).toBeDefined()
         expect(equalRule?.message).toBe('role must be equal to admin')
@@ -29,8 +31,8 @@ describe('equal decorator', () => {
     })
 
     it('should have equal validator with number argument', () => {
-        const meta = getFieldMetadata(Sample.prototype, 'number1')
-        const equalRule = meta.validators?.find(v => v.type === 'equal')
+        const meta = classMeta.getFieldMetadata('number1')
+        const equalRule = meta.getValidators()?.find(v => v.type === 'equal')
 
         expect(equalRule).toBeDefined()
         expect(equalRule?.message).toBe('number1 must be equal to 3')
@@ -39,15 +41,15 @@ describe('equal decorator', () => {
     })
 
     it('should not have equal validator when not decorated', () => {
-        const meta = getFieldMetadata(Sample.prototype, 'number2')
-        const equalRule = meta.validators?.find(v => v.type === 'equal')
+        const meta = classMeta.getFieldMetadata('number2')
+        const equalRule = meta.getValidators()?.find(v => v.type === 'equal')
 
         expect(equalRule).toBeUndefined()
     })
 
     it('should have equal validator with null argument', () => {
-        const meta = getFieldMetadata(Sample.prototype, 'nullValue')
-        const equalRule = meta.validators?.find(v => v.type === 'equal')
+        const meta = classMeta.getFieldMetadata('nullValue')
+        const equalRule = meta.getValidators()?.find(v => v.type === 'equal')
 
         expect(equalRule).toBeDefined()
         expect(equalRule?.message).toBe('nullValue must be equal to null')
@@ -58,8 +60,8 @@ describe('equal decorator', () => {
     })
 
     it('should have equal validator with undefined argument', () => {
-        const meta = getFieldMetadata(Sample.prototype, 'undefinedValue')
-        const equalRule = meta.validators?.find(v => v.type === 'equal')
+        const meta = classMeta.getFieldMetadata('undefinedValue')
+        const equalRule = meta.getValidators()?.find(v => v.type === 'equal')
 
         expect(equalRule).toBeDefined()
         expect(equalRule?.message).toBe('undefinedValue must be equal to undefined')

--- a/packages/express-cargo/tests/validator/max.test.ts
+++ b/packages/express-cargo/tests/validator/max.test.ts
@@ -1,5 +1,5 @@
 import { max } from '../../src/validator'
-import { getFieldMetadata } from '../../src/metadata'
+import { CargoClassMetadata } from '../../src/metadata'
 
 describe('max decorator', () => {
     class Sample {
@@ -9,9 +9,11 @@ describe('max decorator', () => {
         number2!: number
     }
 
+    const classMeta = new CargoClassMetadata(Sample.prototype)
+
     it('should have max validator metadata', () => {
-        const meta = getFieldMetadata(Sample.prototype, 'number1')
-        const maxRule = meta.validators?.find(v => v.type === 'max')
+        const meta = classMeta.getFieldMetadata('number1')
+        const maxRule = meta.getValidators()?.find(v => v.type === 'max')
 
         expect(maxRule).toBeDefined()
         expect(maxRule?.message).toBe('number1 must be <= 20')
@@ -20,8 +22,8 @@ describe('max decorator', () => {
     })
 
     it('should not have max validator metadata', () => {
-        const meta = getFieldMetadata(Sample.prototype, 'number2')
-        const maxRule = meta.validators?.find(v => v.type === 'max')
+        const meta = classMeta.getFieldMetadata('number2')
+        const maxRule = meta.getValidators()?.find(v => v.type === 'max')
 
         expect(maxRule).toBeUndefined()
     })

--- a/packages/express-cargo/tests/validator/min.test.ts
+++ b/packages/express-cargo/tests/validator/min.test.ts
@@ -1,5 +1,5 @@
 import { min } from '../../src/validator'
-import { getFieldMetadata } from '../../src/metadata'
+import { CargoClassMetadata } from '../../src/metadata'
 
 describe('min decorator', () => {
     class Sample {
@@ -9,9 +9,11 @@ describe('min decorator', () => {
         number2!: number
     }
 
+    const classMeta = new CargoClassMetadata(Sample.prototype)
+
     it('should have min validator metadata', () => {
-        const meta = getFieldMetadata(Sample.prototype, 'number1')
-        const minRule = meta.validators?.find(v => v.type === 'min')
+        const meta = classMeta.getFieldMetadata('number1')
+        const minRule = meta.getValidators()?.find(v => v.type === 'min')
 
         expect(minRule).toBeDefined()
         expect(minRule?.message).toBe('number1 must be >= 10')
@@ -20,8 +22,8 @@ describe('min decorator', () => {
     })
 
     it('should not have min validator metadata', () => {
-        const meta = getFieldMetadata(Sample.prototype, 'number2')
-        const minRule = meta.validators?.find(v => v.type === 'min')
+        const meta = classMeta.getFieldMetadata('number2')
+        const minRule = meta.getValidators()?.find(v => v.type === 'min')
 
         expect(minRule).toBeUndefined()
     })

--- a/packages/express-cargo/tests/validator/notEqual.test.ts
+++ b/packages/express-cargo/tests/validator/notEqual.test.ts
@@ -1,5 +1,5 @@
 import { notEqual } from '../../src/validator'
-import { getFieldMetadata } from '../../src/metadata'
+import { CargoClassMetadata } from '../../src/metadata'
 
 describe('notEqual decorator', () => {
     class Sample {
@@ -18,9 +18,11 @@ describe('notEqual decorator', () => {
         undefinedValue!: undefined
     }
 
+    const classMeta = new CargoClassMetadata(Sample.prototype)
+
     it('should not have equal validator with string argument', () => {
-        const meta = getFieldMetadata(Sample.prototype, 'role')
-        const notEqualRule = meta.validators?.find(v => v.type === 'notEqual')
+        const meta = classMeta.getFieldMetadata('role')
+        const notEqualRule = meta.getValidators()?.find(v => v.type === 'notEqual')
 
         expect(notEqualRule).toBeDefined()
         expect(notEqualRule?.message).toBe('role must not be equal to admin')
@@ -29,8 +31,8 @@ describe('notEqual decorator', () => {
     })
 
     it('should not have equal validator with number argument', () => {
-        const meta = getFieldMetadata(Sample.prototype, 'number1')
-        const notEqualRule = meta.validators?.find(v => v.type === 'notEqual')
+        const meta = classMeta.getFieldMetadata('number1')
+        const notEqualRule = meta.getValidators()?.find(v => v.type === 'notEqual')
 
         expect(notEqualRule).toBeDefined()
         expect(notEqualRule?.message).toBe('number1 must not be equal to 3')
@@ -41,15 +43,15 @@ describe('notEqual decorator', () => {
     })
 
     it('should not have equal validator when not decorated', () => {
-        const meta = getFieldMetadata(Sample.prototype, 'number2')
-        const notEqualRule = meta.validators?.find(v => v.type === 'notEqual')
+        const meta = classMeta.getFieldMetadata('number2')
+        const notEqualRule = meta.getValidators()?.find(v => v.type === 'notEqual')
 
         expect(notEqualRule).toBeUndefined()
     })
 
     it('should not have equal validator with null argument', () => {
-        const meta = getFieldMetadata(Sample.prototype, 'nullValue')
-        const notEqualRule = meta.validators?.find(v => v.type === 'notEqual')
+        const meta = classMeta.getFieldMetadata('nullValue')
+        const notEqualRule = meta.getValidators()?.find(v => v.type === 'notEqual')
 
         expect(notEqualRule).toBeDefined()
         expect(notEqualRule?.message).toBe('nullValue must not be equal to null')
@@ -60,8 +62,8 @@ describe('notEqual decorator', () => {
     })
 
     it('should not have equal validator with undefined argument', () => {
-        const meta = getFieldMetadata(Sample.prototype, 'undefinedValue')
-        const notEqualRule = meta.validators?.find(v => v.type === 'notEqual')
+        const meta = classMeta.getFieldMetadata('undefinedValue')
+        const notEqualRule = meta.getValidators()?.find(v => v.type === 'notEqual')
 
         expect(notEqualRule).toBeDefined()
         expect(notEqualRule?.message).toBe('undefinedValue must not be equal to undefined')

--- a/packages/express-cargo/tests/validator/prefix.test.ts
+++ b/packages/express-cargo/tests/validator/prefix.test.ts
@@ -1,5 +1,5 @@
 import { prefix } from '../../src/validator'
-import { getFieldMetadata } from '../../src/metadata'
+import { CargoClassMetadata } from '../../src/metadata'
 
 describe('prefix decorator', () => {
     class Sample {
@@ -9,9 +9,11 @@ describe('prefix decorator', () => {
         id2!: string
     }
 
+    const classMeta = new CargoClassMetadata(Sample.prototype)
+
     it('should have prefix metadata', () => {
-        const meta = getFieldMetadata(Sample.prototype, 'id1')
-        const prefixRule = meta.validators?.find(v => v.type === 'prefix')
+        const meta = classMeta.getFieldMetadata('id1')
+        const prefixRule = meta.getValidators()?.find(v => v.type === 'prefix')
 
         expect(prefixRule).toBeDefined()
         expect(prefixRule?.message).toBe('id1 must start with id')
@@ -20,8 +22,8 @@ describe('prefix decorator', () => {
     })
 
     it('should not have prefix metadata', () => {
-        const meta = getFieldMetadata(Sample.prototype, 'id2')
-        const prefixRule = meta.validators?.find(v => v.type === 'prefix')
+        const meta = classMeta.getFieldMetadata('id2')
+        const prefixRule = meta.getValidators()?.find(v => v.type === 'prefix')
 
         expect(prefixRule).toBeUndefined()
     })

--- a/packages/express-cargo/tests/validator/range.test.ts
+++ b/packages/express-cargo/tests/validator/range.test.ts
@@ -1,5 +1,5 @@
 import {range} from '../../src/validator';
-import {getFieldMetadata} from '../../src/metadata';
+import { CargoClassMetadata } from '../../src/metadata'
 
 describe('range decorator', () => {
     class Sample {
@@ -9,9 +9,11 @@ describe('range decorator', () => {
         number2!: number;
     }
 
+    const classMeta = new CargoClassMetadata(Sample.prototype)
+
     it('should have range validator metadata', () => {
-        const meta = getFieldMetadata(Sample.prototype, 'number1');
-        const rangeRule = meta.validators?.find(v => v.type === 'range');
+        const meta = classMeta.getFieldMetadata('number1')
+        const rangeRule = meta.getValidators()?.find(v => v.type === 'range')
 
         expect(rangeRule).toBeDefined();
         expect(rangeRule?.message).toBe('number1 must be between 5 and 15');
@@ -24,8 +26,8 @@ describe('range decorator', () => {
     });
 
     it('should not have range validator metadata', () => {
-        const meta = getFieldMetadata(Sample.prototype, 'number2');
-        const rangeRule = meta.validators?.find(v => v.type === 'range');
+        const meta = classMeta.getFieldMetadata('number2')
+        const rangeRule = meta.getValidators()?.find(v => v.type === 'range')
 
         expect(rangeRule).toBeUndefined();
     });

--- a/packages/express-cargo/tests/validator/suffix.test.ts
+++ b/packages/express-cargo/tests/validator/suffix.test.ts
@@ -1,5 +1,5 @@
 import { suffix } from '../../src/validator'
-import { getFieldMetadata } from '../../src/metadata'
+import { CargoClassMetadata } from '../../src/metadata'
 
 describe('suffix decorator', () => {
     class Sample {
@@ -9,9 +9,11 @@ describe('suffix decorator', () => {
         link2!: string
     }
 
+    const classMeta = new CargoClassMetadata(Sample.prototype)
+
     it('should have suffix metadata', () => {
-        const meta = getFieldMetadata(Sample.prototype, 'link1')
-        const suffixRule = meta.validators?.find(v => v.type === 'suffix')
+        const meta = classMeta.getFieldMetadata('link1')
+        const suffixRule = meta.getValidators()?.find(v => v.type === 'suffix')
 
         expect(suffixRule).toBeDefined()
         expect(suffixRule?.message).toBe('link1 must end with .com')
@@ -20,8 +22,8 @@ describe('suffix decorator', () => {
     })
 
     it('should not have suffix metadata', () => {
-        const meta = getFieldMetadata(Sample.prototype, 'link2')
-        const suffixRule = meta.validators?.find(v => v.type === 'suffix')
+        const meta = classMeta.getFieldMetadata('link2')
+        const suffixRule = meta.getValidators()?.find(v => v.type === 'suffix')
 
         expect(suffixRule).toBeUndefined()
     })


### PR DESCRIPTION
metadata 를 class 로 관리하도록 수정합니다.

- 기존 metadata 관련 함수들을 모두 제거하였습니다.
- CargoClassMetadata class 를 추가합니다.
  - 특정 class 에 저장된 field metadata 를 관리합니다
- CargoFieldMetadata class 를 추가합니다.
  - 특정 필드에 저장된 decorator 정보를 관리합니다