### PR TITLE
feat: add oneOf property decorator validator

### DIFF
--- a/packages/express-cargo/src/validator.ts
+++ b/packages/express-cargo/src/validator.ts
@@ -78,11 +78,15 @@ export function range(min: number, max: number): PropertyDecorator {
   };
 }
 
-export function oneOf(options: any[]): PropertyDecorator {
+/**
+ * 속성 값이 주어진 값들 중 하나인지 확인합니다.
+ * @param options 허용되는 값의 배열.
+ */
+export function oneOf<T extends readonly any[]>(options: T): PropertyDecorator {
     return (target: Object, propertyKey: string | symbol): void => {
         addValidator(target, propertyKey, {
             type: 'oneOf',
-            validate: (value: any) => options.includes(value),
+            validate: (value: unknown): value is T[number] => options.includes(value as T[number]),
             message: `${String(propertyKey)} must be one of ${options.join(', ')}`,
         })
     }

--- a/packages/express-cargo/tests/validator/oneOf.test.ts
+++ b/packages/express-cargo/tests/validator/oneOf.test.ts
@@ -3,13 +3,19 @@ import { CargoClassMetadata } from '../../src/metadata'
 
 describe('oneOf decorator', () => {
     class Sample {
-        @oneOf([10, 20, 30])
+        @oneOf([10, 20, 30] as const)
         element1!: number
 
-        @oneOf(['foo', 'bar'])
-        element2!: string
+        @oneOf(['foo', 'bar'] as const)
+        element2!: number
 
         element3!: number
+
+        @oneOf([] as const)
+        element4!: number
+
+        @oneOf([1, 'a'] as const)
+        element5!: 1 | 'a'
     }
 
     const classMeta = new CargoClassMetadata(Sample.prototype)
@@ -24,6 +30,8 @@ describe('oneOf decorator', () => {
         expect(validator?.validate(10)).toBe(true)
         expect(validator?.validate(25)).toBe(false)
         expect(validator?.validate(30)).toBe(true)
+        expect(validator?.validate(null)).toBe(false)
+        expect(validator?.validate(undefined)).toBe(false)
     })
 
     it('should add oneOf validator to element2 with string options', () => {
@@ -34,7 +42,7 @@ describe('oneOf decorator', () => {
         expect(validator?.message).toBe('element2 must be one of foo, bar')
 
         expect(validator?.validate('foo')).toBe(true)
-        expect(validator?.validate(10)).toBe(false)
+        expect(validator?.validate('loo')).toBe(false)
     })
 
     it('should not have oneOf validator on element3', () => {
@@ -42,5 +50,26 @@ describe('oneOf decorator', () => {
         const validator = meta.getValidators()?.find(v => v.type === 'oneOf')
 
         expect(validator).toBeUndefined()
+    })
+
+    it('should not validate anything on element4', () => {
+        const meta = classMeta.getFieldMetadata('element4')
+        const validator = meta.getValidators()?.find(v => v.type === 'oneOf')
+
+        expect(validator).toBeDefined()
+
+        expect(validator?.validate('foo')).toBe(false)
+        expect(validator?.validate(10)).toBe(false)
+    })
+
+    it('should validate mixed type of elements on element5', () => {
+        const meta = classMeta.getFieldMetadata('element5')
+        const validator = meta.getValidators()?.find(v => v.type === 'oneOf')
+
+        expect(validator).toBeDefined()
+
+        expect(validator?.validate('a')).toBe(true)
+        expect(validator?.validate(1)).toBe(true)
+        expect(validator?.validate(2)).toBe(false)
     })
 })


### PR DESCRIPTION
아래 사항 관련해서 리팩토링이 필요하다 vs 필요없다 의견 주시면 감사하겠습니다.
<html>
<body>
<!--StartFragment--><h1>사용상 불편할 수 있는 부분</h1>

상황 | 안전한가? | 설명
-- | -- | --
@oneOf(['a', 'b']) on string | ✅ | 타입 일치, OK
@oneOf([1, 2, 3]) on number | ✅ | 타입 일치, OK
@oneOf(['a', 'b']) on number | ❌ | 타입 불일치, 런타임은 OK지만 사용상 버그 가능
@oneOf([true, false]) on boolean | ✅ | 타입 일치, OK


<p>현재 코드</p>
<pre><code class="language-tsx">export function oneOf(options: any[]): PropertyDecorator {
    return (target: Object, propertyKey: string | symbol): void =&gt; {
        addValidator(target, propertyKey, {
            type: 'oneOf',
            validate: (value: any) =&gt; options.includes(value),
            message: `${String(propertyKey)} must be one of ${options.join(', ')}`,
        })
    }
}
</code></pre>
<h2>✅ 해결 방향</h2>
<h3>1. 데코레이터에서 타입 안전성을 강제</h3>
<pre><code class="language-tsx">export function oneOf&lt;T extends readonly any[]&gt;(options: T): PropertyDecorator {
    return (target, propertyKey) =&gt; {
        addValidator(target, propertyKey, {
            type: 'oneOf',
            validate: (value: unknown): value is T[number] =&gt; options.includes(value as T[number]),
            message: `${String(propertyKey)} must be one of [${options.join(', ')}]`,
        })
    }
}

</code></pre>
<p>이건 어느 정도 안전하지만, 완전한 타입 추론까지는 안 됨</p>
<hr>
<h3>2. 유저가 사용할 때 타입 강제</h3>
<p>사용 쪽에서 아래처럼 쓰도록 가이드</p>
<pre><code class="language-tsx">@oneOf(['foo', 'bar'] as const)
value!: 'foo' | 'bar'
</code></pre>
<p>또는</p>
<pre><code class="language-tsx">const GENDERS = ['male', 'female'] as const

@oneOf(GENDERS)
gender!: typeof GENDERS[number]
</code></pre>
<h3>3. docs 문서에 명시</h3>
<blockquote>
<p>사용 가이드 문서나 주석에서 &quot;필드 타입과 oneOf 값 타입이 일치해야 합니다&quot; 라고 명시</p>
</blockquote>
<!-- notionvc: 6d5d5d08-2f9c-4179-9593-b5e9207d7b38 --><!--EndFragment-->
</body>
</html>