### PR TITLE
fix: Remove null/undefined cases from equal/notEqual example apps and tests due to optional decorator update

### DIFF
--- a/apps/example/src/routers/validator.ts
+++ b/apps/example/src/routers/validator.ts
@@ -15,14 +15,6 @@ class EqualExample {
     @body()
     @equal(true)
     boolean!: boolean
-
-    @body()
-    @equal(null)
-    nullValue!: null
-
-    @body()
-    @equal(undefined)
-    undefinedValue!: undefined
 }
 
 router.post('/equal', bindingCargo(EqualExample), (req, res) => {
@@ -42,14 +34,6 @@ class NotEqualExample {
     @body()
     @notEqual(true)
     boolean!: boolean
-
-    @body()
-    @notEqual(null)
-    nullValue!: null
-
-    @body()
-    @notEqual(undefined)
-    undefinedValue!: undefined
 }
 
 router.post('/not-equal', bindingCargo(NotEqualExample), (req, res) => {

--- a/packages/express-cargo/tests/validator/equal.test.ts
+++ b/packages/express-cargo/tests/validator/equal.test.ts
@@ -10,12 +10,6 @@ describe('equal decorator', () => {
         number1!: number
 
         number2!: number
-
-        @equal(null)
-        nullValue!: null
-
-        @equal(undefined)
-        undefinedValue!: undefined
     }
 
     const classMeta = new CargoClassMetadata(Sample.prototype)
@@ -45,29 +39,5 @@ describe('equal decorator', () => {
         const equalRule = meta.getValidators()?.find(v => v.type === 'equal')
 
         expect(equalRule).toBeUndefined()
-    })
-
-    it('should have equal validator with null argument', () => {
-        const meta = classMeta.getFieldMetadata('nullValue')
-        const equalRule = meta.getValidators()?.find(v => v.type === 'equal')
-
-        expect(equalRule).toBeDefined()
-        expect(equalRule?.message).toBe('nullValue must be equal to null')
-
-        expect(equalRule?.validate('not-null')).toBe(false)
-        expect(equalRule?.validate(null)).toBe(true)
-        expect(equalRule?.validate(undefined)).toBe(false)
-    })
-
-    it('should have equal validator with undefined argument', () => {
-        const meta = classMeta.getFieldMetadata('undefinedValue')
-        const equalRule = meta.getValidators()?.find(v => v.type === 'equal')
-
-        expect(equalRule).toBeDefined()
-        expect(equalRule?.message).toBe('undefinedValue must be equal to undefined')
-
-        expect(equalRule?.validate('not-undefined')).toBe(false)
-        expect(equalRule?.validate(undefined)).toBe(true)
-        expect(equalRule?.validate(null)).toBe(false)
     })
 })

--- a/packages/express-cargo/tests/validator/notEqual.test.ts
+++ b/packages/express-cargo/tests/validator/notEqual.test.ts
@@ -10,12 +10,6 @@ describe('notEqual decorator', () => {
         number1!: number
 
         number2!: number
-
-        @notEqual(null)
-        nullValue!: null
-
-        @notEqual(undefined)
-        undefinedValue!: undefined
     }
 
     const classMeta = new CargoClassMetadata(Sample.prototype)
@@ -47,29 +41,5 @@ describe('notEqual decorator', () => {
         const notEqualRule = meta.getValidators()?.find(v => v.type === 'notEqual')
 
         expect(notEqualRule).toBeUndefined()
-    })
-
-    it('should not have equal validator with null argument', () => {
-        const meta = classMeta.getFieldMetadata('nullValue')
-        const notEqualRule = meta.getValidators()?.find(v => v.type === 'notEqual')
-
-        expect(notEqualRule).toBeDefined()
-        expect(notEqualRule?.message).toBe('nullValue must not be equal to null')
-
-        expect(notEqualRule?.validate('not-null')).toBe(true)
-        expect(notEqualRule?.validate(null)).toBe(false)
-        expect(notEqualRule?.validate(undefined)).toBe(true)
-    })
-
-    it('should not have equal validator with undefined argument', () => {
-        const meta = classMeta.getFieldMetadata('undefinedValue')
-        const notEqualRule = meta.getValidators()?.find(v => v.type === 'notEqual')
-
-        expect(notEqualRule).toBeDefined()
-        expect(notEqualRule?.message).toBe('undefinedValue must not be equal to undefined')
-
-        expect(notEqualRule?.validate('not-undefined')).toBe(true)
-        expect(notEqualRule?.validate(undefined)).toBe(false)
-        expect(notEqualRule?.validate(null)).toBe(true)
     })
 })


### PR DESCRIPTION
optional decorate update에 따른 null, undefined 값이 들어오면 에러를 리턴하는 변화에 따라 test 코드, example app 코드를 수정했습니다.