### PR TITLE
fix: add error handling for type conversion failures

### DIFF
--- a/packages/express-cargo/src/binding.ts
+++ b/packages/express-cargo/src/binding.ts
@@ -104,15 +104,27 @@ function bindObject(
             case String:
                 targetObject[property] = String(value)
                 break
-            case Number:
-                targetObject[property] = isNaN(Number(value)) ? value : Number(value)
+            case Number: {
+                const parsedNumber = Number(value)
+                if (isNaN(parsedNumber)) {
+                    errors.push(new CargoFieldError(getErrorKey(sourceKey, key), `${key} must be a valid number`))
+                    continue
+                }
+                targetObject[property] = parsedNumber
                 break
+            }
             case Boolean:
                 targetObject[property] = value === true || value === 'true'
                 break
-            case Date:
-                targetObject[property] = new Date(value)
+            case Date: {
+                const parsedDate = new Date(value)
+                if (isNaN(parsedDate.getTime())) {
+                    errors.push(new CargoFieldError(getErrorKey(sourceKey, key), `${key} must be a valid date`))
+                    continue
+                }
+                targetObject[property] = parsedDate
                 break
+            }
             default: {
                 const nextSources = { ...sources, [currentSource]: value }
                 targetObject[property] = bindObject(meta.type, nextSources, errors, getErrorKey(sourceKey, key))

--- a/packages/express-cargo/src/binding.ts
+++ b/packages/express-cargo/src/binding.ts
@@ -106,7 +106,7 @@ function bindObject(
                 break
             case Number: {
                 const parsedNumber = Number(value)
-                if (isNaN(parsedNumber)) {
+                if (isNaN(parsedNumber) || (typeof value === 'string' && value.trim() === '')) {
                     errors.push(new CargoFieldError(getErrorKey(sourceKey, key), `${key} must be a valid number`))
                     continue
                 }


### PR DESCRIPTION
`Number`와 `Date`를 변화할 때 변환 과정에서 `NaN`이 나온 경우 에러를 반환하도록 로직을 수정합니다. 