### PR TITLE
feat: add logic for handling single-property arrays with @array decorator

### DIFF
--- a/packages/express-cargo/src/decorators.ts
+++ b/packages/express-cargo/src/decorators.ts
@@ -1,10 +1,28 @@
 import { CargoClassMetadata } from './metadata'
+import { ArrayElementType } from './types'
+
+const TYPE_MAP = {
+    string: String,
+    number: Number,
+    boolean: Boolean,
+    date: Date,
+} as const
 
 export function optional(): PropertyDecorator {
     return (target: any, propertyKey: string | symbol) => {
         const classMeta = new CargoClassMetadata(target)
         const fieldMeta = classMeta.getFieldMetadata(propertyKey)
         fieldMeta.setOptional(true)
+        classMeta.setFieldMetadata(propertyKey, fieldMeta)
+    }
+}
+
+export function array(elementType: ArrayElementType): PropertyDecorator {
+    return (target: any, propertyKey: string | symbol) => {
+        const classMeta = new CargoClassMetadata(target)
+        const fieldMeta = classMeta.getFieldMetadata(propertyKey)
+        const actualType = typeof elementType === 'string' ? TYPE_MAP[elementType] : elementType
+        fieldMeta.setArrayElementType(actualType)
         classMeta.setFieldMetadata(propertyKey, fieldMeta)
     }
 }

--- a/packages/express-cargo/src/metadata.ts
+++ b/packages/express-cargo/src/metadata.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 import type { Request } from 'express'
-import { Source, ValidatorRule } from './types'
+import { ArrayElementType, Source, validArrayElementType, ValidatorRule } from './types'
 
 export class CargoClassMetadata {
     private target: any
@@ -110,6 +110,7 @@ export class CargoFieldMetadata {
     private key: string | symbol
     private source: Source
     private optional: boolean
+    private arrayElementType: validArrayElementType | undefined
     private validators: ValidatorRule[]
     private transformer: ((value: any) => any) | undefined
     private requestTransformer: ((req: Request) => any) | undefined
@@ -157,6 +158,14 @@ export class CargoFieldMetadata {
 
     setOptional(optional: boolean): void {
         this.optional = optional
+    }
+
+    getArrayElementType(): validArrayElementType | undefined {
+        return this.arrayElementType
+    }
+
+    setArrayElementType(arrayElementType: validArrayElementType): void {
+        this.arrayElementType = arrayElementType
     }
 
     getTransformer(): ((value: any) => any) | undefined {

--- a/packages/express-cargo/src/types.ts
+++ b/packages/express-cargo/src/types.ts
@@ -1,5 +1,9 @@
 export type Source = 'body' | 'query' | 'params' | 'header' | 'session'
 
+type ClassConstructor = new () => any
+export type validArrayElementType = typeof String | typeof Number | typeof Boolean | typeof Date | ClassConstructor
+export type ArrayElementType = validArrayElementType | 'string' | 'number' | 'boolean' | 'date'
+
 type ValidatorFunction = (value: any) => boolean
 export type ValidatorRule = {
     type: string

--- a/packages/express-cargo/tests/decorator/array.test.ts
+++ b/packages/express-cargo/tests/decorator/array.test.ts
@@ -1,0 +1,58 @@
+import { array } from '../../src/decorators'
+import { CargoClassMetadata } from '../../src/metadata'
+
+class CustomClass {}
+
+describe('array decorator', () => {
+    class Sample {
+        @array(String)
+        stringArray!: string[]
+
+        @array(Number)
+        numberArray!: number[]
+
+        @array(Boolean)
+        booleanArray!: boolean[]
+
+        @array(Date)
+        dateArray!: Date[]
+
+        @array('string')
+        stringLiteralArray!: string[]
+
+        @array(CustomClass)
+        customClassArray!: CustomClass[]
+    }
+
+    const classMeta = new CargoClassMetadata(Sample.prototype)
+
+    it('should correctly set array element type to String', () => {
+        const meta = classMeta.getFieldMetadata('stringArray')
+        expect(meta.getArrayElementType()).toBe(String)
+    })
+
+    it('should correctly set array element type to Number', () => {
+        const meta = classMeta.getFieldMetadata('numberArray')
+        expect(meta.getArrayElementType()).toBe(Number)
+    })
+
+    it('should correctly set array element type to Boolean', () => {
+        const meta = classMeta.getFieldMetadata('booleanArray')
+        expect(meta.getArrayElementType()).toBe(Boolean)
+    })
+
+    it('should correctly set array element type to Date', () => {
+        const meta = classMeta.getFieldMetadata('dateArray')
+        expect(meta.getArrayElementType()).toBe(Date)
+    })
+
+    it('should correctly map and set array element type from string literal', () => {
+        const meta = classMeta.getFieldMetadata('stringLiteralArray')
+        expect(meta.getArrayElementType()).toBe(String)
+    })
+
+    it('should correctly set array element type to a custom class', () => {
+        const meta = classMeta.getFieldMetadata('customClassArray')
+        expect(meta.getArrayElementType()).toBe(CustomClass)
+    })
+})


### PR DESCRIPTION
@array 데코레이터를 추가하여 단일 속성 배열을 처리할 수 있는 로직을 추가합니다. 

객체의 경우 현재 단순히 처리를 하고 있습니다. 만약 객체에 `validate`, `transfrom` 데코레이터를 등록해서 사용하는 경우의 처리가 필요할까요? `source`, `virtual`, `request`를 추가하는 경우도 있을 까요..?