### PR TITLE
docs: package manager tab

### DIFF
--- a/apps/docs/docs/installation.md
+++ b/apps/docs/docs/installation.md
@@ -1,12 +1,25 @@
 ## install
-```shell
-# With pnpm
-pnpm add express-cargo reflect-metadata
 
-# Or with npm
-npm install express-cargo reflect-metadata
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
-```
+<Tabs groupId="package-manager">
+    <TabItem value="npm" label="npm">
+        ```
+        npm install express-cargo reflect-metadata
+        ```
+    </TabItem>
+    <TabItem value="yarn" label="yarn">
+        ```
+        yarn add express-cargo reflect-metadata
+        ```
+    </TabItem>
+    <TabItem value="pnpm" label="pnpm">
+        ```
+        pnpm add express-cargo reflect-metadata
+        ```
+    </TabItem>
+</Tabs>
 
 ## Requirements
 


### PR DESCRIPTION
docs 에서 package manager 를 tab 형식으로 표시하도록 수정합니다

<img width="1025" height="354" alt="image" src="https://github.com/user-attachments/assets/da570227-4e51-4070-adc0-ede1b30cb411" />
