### PR TITLE
refactor: cache CargoClassMetadata to aviod redundant construction per request

### DIFF
--- a/packages/express-cargo/src/binding.ts
+++ b/packages/express-cargo/src/binding.ts
@@ -1,13 +1,13 @@
 import type { Request, RequestHandler } from 'express'
 
-import type { BindContext, BindSources } from './types'
+import { BindContext, BindSources, ClassConstructor } from './types'
 import { CargoFieldError, CargoValidationError, CargoTransformFieldError, Source, TypeResolver, TypeThunk, TypeOptions } from './types'
 import { CargoClassMetadata, CargoFieldMetadata } from './metadata'
 import { getCargoErrorHandler } from './errorHandler'
 
-const metaCache = new Map<Function, CargoClassMetadata>()
+const metaCache = new Map<ClassConstructor, CargoClassMetadata>()
 
-function getOrCreateMeta(classConstructor: any): CargoClassMetadata {
+function getOrCreateMeta(classConstructor: ClassConstructor): CargoClassMetadata {
     let meta = metaCache.get(classConstructor)
     if (!meta) {
         meta = new CargoClassMetadata(classConstructor.prototype)

--- a/packages/express-cargo/src/binding.ts
+++ b/packages/express-cargo/src/binding.ts
@@ -1,21 +1,9 @@
 import type { Request, RequestHandler } from 'express'
 
-import { BindContext, BindSources, ClassConstructor } from './types'
+import { BindContext, BindSources } from './types'
 import { CargoFieldError, CargoValidationError, CargoTransformFieldError, Source, TypeResolver, TypeThunk, TypeOptions } from './types'
 import { CargoClassMetadata, CargoFieldMetadata } from './metadata'
 import { getCargoErrorHandler } from './errorHandler'
-
-const metaCache = new Map<ClassConstructor, CargoClassMetadata>()
-
-function getOrCreateMeta(classConstructor: ClassConstructor): CargoClassMetadata {
-    let meta = metaCache.get(classConstructor)
-    if (!meta) {
-        meta = new CargoClassMetadata(classConstructor.prototype)
-        meta.markBindingCargoCalled()
-        metaCache.set(classConstructor, meta)
-    }
-    return meta
-}
 
 function getErrorKey(sourceKey: string, currentKey: string): string {
     return sourceKey ? `${sourceKey}.${currentKey}` : currentKey
@@ -198,7 +186,8 @@ function typeCasting(
     // Recursive binding: Transform nested plain objects into class instances
     if (isClass(targetClass) && typeof value === 'object' && value !== null) {
         const nextSources = { ...sources, [currentSource]: value }
-        const nestedMeta = getOrCreateMeta(targetClass)
+        const nestedMeta = new CargoClassMetadata(targetClass.prototype)
+        nestedMeta.markBindingCargoCalled()
         return bindObject(targetClass, nestedMeta, nextSources, errors, getErrorKey(sourceKey, key))
     }
 
@@ -333,7 +322,8 @@ function bindVirtual({ metaClass, targetObject, errors, sourceKey }: BindContext
  * ```
  */
 export function bindingCargo<T extends object = any>(cargoClass: new () => T): RequestHandler {
-    const metaClass = getOrCreateMeta(cargoClass)
+    const metaClass = new CargoClassMetadata(cargoClass.prototype)
+    metaClass.markBindingCargoCalled()
 
     return (req, res, next) => {
         try {

--- a/packages/express-cargo/src/binding.ts
+++ b/packages/express-cargo/src/binding.ts
@@ -11,6 +11,7 @@ function getOrCreateMeta(classConstructor: ClassConstructor): CargoClassMetadata
     let meta = metaCache.get(classConstructor)
     if (!meta) {
         meta = new CargoClassMetadata(classConstructor.prototype)
+        meta.markBindingCargoCalled()
         metaCache.set(classConstructor, meta)
     }
     return meta
@@ -206,8 +207,6 @@ function typeCasting(
 }
 
 function bindObject(objectClass: any, metaClass: CargoClassMetadata, sources: BindSources, errors: CargoFieldError[], sourceKey: string = ''): any {
-    metaClass.markBindingCargoCalled()
-
     const targetObject = new objectClass()
     const context: BindContext = {
         metaClass,

--- a/packages/express-cargo/src/binding.ts
+++ b/packages/express-cargo/src/binding.ts
@@ -5,6 +5,17 @@ import { CargoFieldError, CargoValidationError, CargoTransformFieldError, Source
 import { CargoClassMetadata, CargoFieldMetadata } from './metadata'
 import { getCargoErrorHandler } from './errorHandler'
 
+const metaCache = new Map<Function, CargoClassMetadata>()
+
+function getOrCreateMeta(classConstructor: any): CargoClassMetadata {
+    let meta = metaCache.get(classConstructor)
+    if (!meta) {
+        meta = new CargoClassMetadata(classConstructor.prototype)
+        metaCache.set(classConstructor, meta)
+    }
+    return meta
+}
+
 function getErrorKey(sourceKey: string, currentKey: string): string {
     return sourceKey ? `${sourceKey}.${currentKey}` : currentKey
 }
@@ -186,16 +197,15 @@ function typeCasting(
     // Recursive binding: Transform nested plain objects into class instances
     if (isClass(targetClass) && typeof value === 'object' && value !== null) {
         const nextSources = { ...sources, [currentSource]: value }
-        return bindObject(targetClass, nextSources, errors, getErrorKey(sourceKey, key))
+        const nestedMeta = getOrCreateMeta(targetClass)
+        return bindObject(targetClass, nestedMeta, nextSources, errors, getErrorKey(sourceKey, key))
     }
 
     // Fallback: Return raw value if no further transformation is possible
     return value
 }
 
-function bindObject(objectClass: any, sources: BindSources, errors: CargoFieldError[], sourceKey: string = ''): any {
-    const metaClass = new CargoClassMetadata(objectClass.prototype)
-
+function bindObject(objectClass: any, metaClass: CargoClassMetadata, sources: BindSources, errors: CargoFieldError[], sourceKey: string = ''): any {
     metaClass.markBindingCargoCalled()
 
     const targetObject = new objectClass()
@@ -324,6 +334,8 @@ function bindVirtual({ metaClass, targetObject, errors, sourceKey }: BindContext
  * ```
  */
 export function bindingCargo<T extends object = any>(cargoClass: new () => T): RequestHandler {
+    const metaClass = getOrCreateMeta(cargoClass)
+
     return (req, res, next) => {
         try {
             const errors: CargoFieldError[] = []
@@ -335,7 +347,7 @@ export function bindingCargo<T extends object = any>(cargoClass: new () => T): R
                 header: req.headers,
                 session: (req as any).session,
             }
-            const cargo = bindObject(cargoClass, sources, errors)
+            const cargo = bindObject(cargoClass, metaClass, sources, errors)
 
             if (errors.length > 0) {
                 throw new CargoValidationError(errors)


### PR DESCRIPTION
현재 `bindingCargo` 함수 내에서 사용자가 입력한 class 객체를 평가하기 위해 매 요청마다 객체를 새롭게 생성해서 사용하고 있어 이를 해결하기 위한 작업을 수행하였습니다.

처음에는 클로저 방식으로 최상위 클래스의 메타데이터만 사전 분석하였으나, 중첩 구조에서는 여전히 매 요청마다 메타데이터를 재생성하는 문제가 있어 모듈 레벨 캐시를 도입하여 모든 클래스의 메타데이터를 일관되게 캐싱하도록 변경하였습니다.