### PR TITLE
docs: add error handler usage guide to README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
 })
 ```
 
-> If `setCargoErrorHandler` is registered, it takes priority over the Express error middleware.
+> If `setCargoErrorHandler` is registered, it takes priority over the Express error middleware. The Express error middleware will only receive the error if `next(err)` is called inside `setCargoErrorHandler`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -161,24 +161,47 @@ Full guide and API reference:
 
 ### Error Handling
 
+When validation fails, `bindingCargo` throws a `CargoValidationError` containing a list of `CargoFieldError` objects. You can handle it using `setCargoErrorHandler` (recommended) or Express's built-in error middleware.
+
+**Option 1: `setCargoErrorHandler` (Recommended)**
+
+Register a global handler once at app startup:
+
 ```ts
 import { setCargoErrorHandler, CargoValidationError } from 'express-cargo'
 
-// Custom error handler
 setCargoErrorHandler((err, req, res, next) => {
-    if (err instanceof CargoValidationError) {
-        res.status(400).json({
+    res.status(400).json({
         error: 'Validation failed',
         details: err.errors.map(e => ({
-                field: e.field,
-                message: e.name
-            }))
-        })
-    } else {
-        next(err)
-    }
+            field: e.field,
+            message: e.message,
+        })),
+    })
 })
 ```
+
+**Option 2: Express Error Middleware**
+
+```ts
+import { CargoValidationError } from 'express-cargo'
+import { Request, Response, NextFunction } from 'express'
+
+app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
+    if (err instanceof CargoValidationError) {
+        return res.status(400).json({
+            error: 'Validation failed',
+            details: err.errors.map(e => ({
+                field: e.field,
+                message: e.message,
+            })),
+        })
+    }
+    next(err)
+})
+```
+
+> If `setCargoErrorHandler` is registered, it takes priority over the Express error middleware.
 
 ## License
 

--- a/apps/docs/docs/examples/validation-errors.md
+++ b/apps/docs/docs/examples/validation-errors.md
@@ -1,1 +1,113 @@
-> How validation errors are structured and returned.
+# Error Handling
+
+When validation fails, `bindingCargo` throws a `CargoValidationError`. You can handle this error using either `setCargoErrorHandler` or Express's built-in error handling middleware.
+
+---
+
+## Error Types
+
+### `CargoValidationError`
+
+Thrown when one or more fields fail validation.
+
+| Property | Type | Description |
+|---|---|---|
+| `name` | `string` | Always `'CargoValidationError'` |
+| `errors` | `CargoFieldError[]` | List of field-level errors |
+
+### `CargoFieldError`
+
+Represents a single field validation failure.
+
+| Property | Type | Description |
+|---|---|---|
+| `name` | `string` | Always `'CargoFieldError'` |
+| `field` | `string \| symbol` | The name of the field that failed |
+| `message` | `string` | The error message |
+
+---
+
+## Option 1: `setCargoErrorHandler` (Recommended)
+
+Register a global handler once at app startup. All validation errors across every route will be handled automatically.
+
+```typescript
+import { setCargoErrorHandler, CargoValidationError } from 'express-cargo'
+
+setCargoErrorHandler((err, req, res, next) => {
+    res.status(400).json({
+        error: 'Validation failed',
+        details: err.errors.map(e => ({
+            field: e.field,
+            message: e.message,
+        })),
+    })
+})
+```
+
+**Example response:**
+```json
+{
+    "error": "Validation failed",
+    "details": [
+        { "field": "email", "message": "email should be a valid email" },
+        { "field": "age", "message": "age must be >= 0" }
+    ]
+}
+```
+
+---
+
+## Option 2: Express Error Middleware
+
+Use Express's standard 4-argument error middleware to catch `CargoValidationError`.
+
+```typescript
+import { CargoValidationError } from 'express-cargo'
+import { Request, Response, NextFunction } from 'express'
+
+app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
+    if (err instanceof CargoValidationError) {
+        return res.status(400).json({
+            error: 'Validation failed',
+            details: err.errors.map(e => ({
+                field: e.field,
+                message: e.message,
+            })),
+        })
+    }
+    next(err)
+})
+```
+
+> **Note:** If `setCargoErrorHandler` is registered, it takes priority. The Express error middleware will only receive the error if `next(err)` is called inside `setCargoErrorHandler`.
+
+---
+
+## Handling Multiple Errors
+
+A single request can fail multiple validations at once. All errors are collected and returned together.
+
+```typescript
+class CreateUserDto {
+    @Body()
+    @Email()
+    email!: string
+
+    @Body()
+    @Min(0)
+    age!: number
+}
+```
+
+If both fields are invalid, `err.errors` will contain two entries:
+
+```json
+{
+    "error": "Validation failed",
+    "details": [
+        { "field": "email", "message": "email should be a valid email" },
+        { "field": "age", "message": "age must be >= 0" }
+    ]
+}
+```

--- a/apps/docs/i18n/de/docusaurus-plugin-content-docs/current/examples/validation-errors.md
+++ b/apps/docs/i18n/de/docusaurus-plugin-content-docs/current/examples/validation-errors.md
@@ -1,1 +1,113 @@
-> Wie Validierungsfehler strukturiert und zurückgegeben werden.
+# Fehlerbehandlung
+
+Wenn die Validierung fehlschlägt, wirft `bindingCargo` einen `CargoValidationError`. Dieser Fehler kann mit `setCargoErrorHandler` oder der eingebauten Express-Fehlerbehandlungs-Middleware verarbeitet werden.
+
+---
+
+## Fehlertypen
+
+### `CargoValidationError`
+
+Wird ausgelöst, wenn ein oder mehrere Felder die Validierung nicht bestehen.
+
+| Eigenschaft | Typ | Beschreibung |
+|---|---|---|
+| `name` | `string` | Immer `'CargoValidationError'` |
+| `errors` | `CargoFieldError[]` | Liste der feldbezogenen Fehler |
+
+### `CargoFieldError`
+
+Repräsentiert einen einzelnen Feldvalidierungsfehler.
+
+| Eigenschaft | Typ | Beschreibung |
+|---|---|---|
+| `name` | `string` | Immer `'CargoFieldError'` |
+| `field` | `string \| symbol` | Der Name des fehlgeschlagenen Feldes |
+| `message` | `string` | Die Fehlermeldung |
+
+---
+
+## Option 1: `setCargoErrorHandler` (Empfohlen)
+
+Einmalig beim App-Start registrieren. Alle Validierungsfehler aller Routen werden automatisch behandelt.
+
+```typescript
+import { setCargoErrorHandler, CargoValidationError } from 'express-cargo'
+
+setCargoErrorHandler((err, req, res, next) => {
+    res.status(400).json({
+        error: 'Validierung fehlgeschlagen',
+        details: err.errors.map(e => ({
+            field: e.field,
+            message: e.message,
+        })),
+    })
+})
+```
+
+**Beispielantwort:**
+```json
+{
+    "error": "Validierung fehlgeschlagen",
+    "details": [
+        { "field": "email", "message": "email should be a valid email" },
+        { "field": "age", "message": "age must be >= 0" }
+    ]
+}
+```
+
+---
+
+## Option 2: Express-Fehler-Middleware
+
+Verwenden Sie die Standard-4-Argument-Fehler-Middleware von Express, um `CargoValidationError` abzufangen.
+
+```typescript
+import { CargoValidationError } from 'express-cargo'
+import { Request, Response, NextFunction } from 'express'
+
+app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
+    if (err instanceof CargoValidationError) {
+        return res.status(400).json({
+            error: 'Validierung fehlgeschlagen',
+            details: err.errors.map(e => ({
+                field: e.field,
+                message: e.message,
+            })),
+        })
+    }
+    next(err)
+})
+```
+
+> **Hinweis:** Wenn `setCargoErrorHandler` registriert ist, hat es Vorrang. Die Express-Fehler-Middleware empfängt den Fehler nur, wenn `next(err)` innerhalb von `setCargoErrorHandler` aufgerufen wird.
+
+---
+
+## Mehrere Fehler behandeln
+
+Eine einzelne Anfrage kann mehrere Validierungen gleichzeitig fehlschlagen lassen. Alle Fehler werden gesammelt und zusammen zurückgegeben.
+
+```typescript
+class CreateUserDto {
+    @Body()
+    @Email()
+    email!: string
+
+    @Body()
+    @Min(0)
+    age!: number
+}
+```
+
+Wenn beide Felder ungültig sind, enthält `err.errors` zwei Einträge:
+
+```json
+{
+    "error": "Validierung fehlgeschlagen",
+    "details": [
+        { "field": "email", "message": "email should be a valid email" },
+        { "field": "age", "message": "age must be >= 0" }
+    ]
+}
+```

--- a/apps/docs/i18n/fr/docusaurus-plugin-content-docs/current/examples/validation-errors.md
+++ b/apps/docs/i18n/fr/docusaurus-plugin-content-docs/current/examples/validation-errors.md
@@ -1,1 +1,113 @@
-> Comment les erreurs de validation sont structurées et retournées.
+# Gestion des erreurs
+
+Lorsque la validation échoue, `bindingCargo` lance une `CargoValidationError`. Vous pouvez gérer cette erreur avec `setCargoErrorHandler` ou le middleware de gestion d'erreurs intégré d'Express.
+
+---
+
+## Types d'erreurs
+
+### `CargoValidationError`
+
+Lancée lorsqu'un ou plusieurs champs échouent à la validation.
+
+| Propriété | Type | Description |
+|---|---|---|
+| `name` | `string` | Toujours `'CargoValidationError'` |
+| `errors` | `CargoFieldError[]` | Liste des erreurs par champ |
+
+### `CargoFieldError`
+
+Représente l'échec de validation d'un seul champ.
+
+| Propriété | Type | Description |
+|---|---|---|
+| `name` | `string` | Toujours `'CargoFieldError'` |
+| `field` | `string \| symbol` | Le nom du champ en échec |
+| `message` | `string` | Le message d'erreur |
+
+---
+
+## Option 1 : `setCargoErrorHandler` (Recommandé)
+
+Enregistrez un gestionnaire global une seule fois au démarrage de l'application. Toutes les erreurs de validation de chaque route seront traitées automatiquement.
+
+```typescript
+import { setCargoErrorHandler, CargoValidationError } from 'express-cargo'
+
+setCargoErrorHandler((err, req, res, next) => {
+    res.status(400).json({
+        error: 'Validation échouée',
+        details: err.errors.map(e => ({
+            field: e.field,
+            message: e.message,
+        })),
+    })
+})
+```
+
+**Exemple de réponse :**
+```json
+{
+    "error": "Validation échouée",
+    "details": [
+        { "field": "email", "message": "email should be a valid email" },
+        { "field": "age", "message": "age must be >= 0" }
+    ]
+}
+```
+
+---
+
+## Option 2 : Middleware d'erreur Express
+
+Utilisez le middleware d'erreur standard à 4 arguments d'Express pour capturer `CargoValidationError`.
+
+```typescript
+import { CargoValidationError } from 'express-cargo'
+import { Request, Response, NextFunction } from 'express'
+
+app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
+    if (err instanceof CargoValidationError) {
+        return res.status(400).json({
+            error: 'Validation échouée',
+            details: err.errors.map(e => ({
+                field: e.field,
+                message: e.message,
+            })),
+        })
+    }
+    next(err)
+})
+```
+
+> **Note :** Si `setCargoErrorHandler` est enregistré, il a la priorité. Le middleware d'erreur Express ne recevra l'erreur que si `next(err)` est appelé à l'intérieur de `setCargoErrorHandler`.
+
+---
+
+## Gestion de plusieurs erreurs
+
+Une seule requête peut échouer à plusieurs validations simultanément. Toutes les erreurs sont collectées et retournées ensemble.
+
+```typescript
+class CreateUserDto {
+    @Body()
+    @Email()
+    email!: string
+
+    @Body()
+    @Min(0)
+    age!: number
+}
+```
+
+Si les deux champs sont invalides, `err.errors` contiendra deux entrées :
+
+```json
+{
+    "error": "Validation échouée",
+    "details": [
+        { "field": "email", "message": "email should be a valid email" },
+        { "field": "age", "message": "age must be >= 0" }
+    ]
+}
+```

--- a/apps/docs/i18n/ja/docusaurus-plugin-content-docs/current/examples/validation-errors.md
+++ b/apps/docs/i18n/ja/docusaurus-plugin-content-docs/current/examples/validation-errors.md
@@ -1,1 +1,113 @@
-> バリデーションエラーの構造と返却方法。
+# エラーハンドリング
+
+バリデーションが失敗すると、`bindingCargo` は `CargoValidationError` をスローします。`setCargoErrorHandler` または Express の標準エラーハンドリングミドルウェアを使用してこのエラーを処理できます。
+
+---
+
+## エラーの種類
+
+### `CargoValidationError`
+
+1つ以上のフィールドがバリデーションに失敗した場合にスローされます。
+
+| プロパティ | 型 | 説明 |
+|---|---|---|
+| `name` | `string` | 常に `'CargoValidationError'` |
+| `errors` | `CargoFieldError[]` | フィールドごとのエラー一覧 |
+
+### `CargoFieldError`
+
+単一フィールドのバリデーション失敗を表します。
+
+| プロパティ | 型 | 説明 |
+|---|---|---|
+| `name` | `string` | 常に `'CargoFieldError'` |
+| `field` | `string \| symbol` | 失敗したフィールド名 |
+| `message` | `string` | エラーメッセージ |
+
+---
+
+## 方法 1: `setCargoErrorHandler`（推奨）
+
+アプリ起動時に一度登録するだけで、すべてのルートのバリデーションエラーを自動的に処理します。
+
+```typescript
+import { setCargoErrorHandler, CargoValidationError } from 'express-cargo'
+
+setCargoErrorHandler((err, req, res, next) => {
+    res.status(400).json({
+        error: 'バリデーション失敗',
+        details: err.errors.map(e => ({
+            field: e.field,
+            message: e.message,
+        })),
+    })
+})
+```
+
+**レスポンス例:**
+```json
+{
+    "error": "バリデーション失敗",
+    "details": [
+        { "field": "email", "message": "email should be a valid email" },
+        { "field": "age", "message": "age must be >= 0" }
+    ]
+}
+```
+
+---
+
+## 方法 2: Express エラーミドルウェア
+
+Express の 4 引数エラーミドルウェアを使用して `CargoValidationError` を処理します。
+
+```typescript
+import { CargoValidationError } from 'express-cargo'
+import { Request, Response, NextFunction } from 'express'
+
+app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
+    if (err instanceof CargoValidationError) {
+        return res.status(400).json({
+            error: 'バリデーション失敗',
+            details: err.errors.map(e => ({
+                field: e.field,
+                message: e.message,
+            })),
+        })
+    }
+    next(err)
+})
+```
+
+> **注意:** `setCargoErrorHandler` が登録されている場合は優先して実行されます。Express エラーミドルウェアがエラーを受け取るのは、`setCargoErrorHandler` 内で `next(err)` が呼び出された場合のみです。
+
+---
+
+## 複数エラーの処理
+
+1つのリクエストで複数のバリデーションが同時に失敗することがあります。すべてのエラーは収集され、まとめて返されます。
+
+```typescript
+class CreateUserDto {
+    @Body()
+    @Email()
+    email!: string
+
+    @Body()
+    @Min(0)
+    age!: number
+}
+```
+
+両方のフィールドが無効な場合、`err.errors` には2つのエントリが含まれます:
+
+```json
+{
+    "error": "バリデーション失敗",
+    "details": [
+        { "field": "email", "message": "email should be a valid email" },
+        { "field": "age", "message": "age must be >= 0" }
+    ]
+}
+```

--- a/apps/docs/i18n/ko/docusaurus-plugin-content-docs/current/examples/validation-errors.md
+++ b/apps/docs/i18n/ko/docusaurus-plugin-content-docs/current/examples/validation-errors.md
@@ -3,4 +3,114 @@ id: validation-errors
 title: 검증 오류 처리
 ---
 
-> How validation errors are structured and returned.
+검증이 실패하면 `bindingCargo`는 `CargoValidationError`를 던집니다. `setCargoErrorHandler` 또는 Express의 기본 에러 처리 미들웨어를 사용하여 이 에러를 처리할 수 있습니다.
+
+---
+
+## 에러 타입
+
+### `CargoValidationError`
+
+하나 이상의 필드가 검증에 실패했을 때 발생합니다.
+
+| 속성 | 타입 | 설명 |
+|---|---|---|
+| `name` | `string` | 항상 `'CargoValidationError'` |
+| `errors` | `CargoFieldError[]` | 필드별 에러 목록 |
+
+### `CargoFieldError`
+
+단일 필드 검증 실패를 나타냅니다.
+
+| 속성 | 타입 | 설명 |
+|---|---|---|
+| `name` | `string` | 항상 `'CargoFieldError'` |
+| `field` | `string \| symbol` | 실패한 필드 이름 |
+| `message` | `string` | 에러 메시지 |
+
+---
+
+## 방법 1: `setCargoErrorHandler` (권장)
+
+앱 시작 시 한 번 등록하면 모든 라우트의 검증 에러가 자동으로 처리됩니다.
+
+```typescript
+import { setCargoErrorHandler, CargoValidationError } from 'express-cargo'
+
+setCargoErrorHandler((err, req, res, next) => {
+    res.status(400).json({
+        error: '검증 실패',
+        details: err.errors.map(e => ({
+            field: e.field,
+            message: e.message,
+        })),
+    })
+})
+```
+
+**응답 예시:**
+```json
+{
+    "error": "검증 실패",
+    "details": [
+        { "field": "email", "message": "email should be a valid email" },
+        { "field": "age", "message": "age must be >= 0" }
+    ]
+}
+```
+
+---
+
+## 방법 2: Express 에러 미들웨어
+
+Express의 4개 인자 에러 미들웨어를 사용하여 `CargoValidationError`를 처리합니다.
+
+```typescript
+import { CargoValidationError } from 'express-cargo'
+import { Request, Response, NextFunction } from 'express'
+
+app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
+    if (err instanceof CargoValidationError) {
+        return res.status(400).json({
+            error: '검증 실패',
+            details: err.errors.map(e => ({
+                field: e.field,
+                message: e.message,
+            })),
+        })
+    }
+    next(err)
+})
+```
+
+> **참고:** `setCargoErrorHandler`가 등록된 경우 우선적으로 실행됩니다. Express 에러 미들웨어는 `setCargoErrorHandler` 내부에서 `next(err)`를 호출한 경우에만 에러를 받습니다.
+
+---
+
+## 여러 에러 처리
+
+하나의 요청에서 여러 검증이 동시에 실패할 수 있습니다. 모든 에러는 수집되어 한 번에 반환됩니다.
+
+```typescript
+class CreateUserDto {
+    @Body()
+    @Email()
+    email!: string
+
+    @Body()
+    @Min(0)
+    age!: number
+}
+```
+
+두 필드가 모두 유효하지 않으면 `err.errors`에 두 개의 항목이 담깁니다:
+
+```json
+{
+    "error": "검증 실패",
+    "details": [
+        { "field": "email", "message": "email should be a valid email" },
+        { "field": "age", "message": "age must be >= 0" }
+    ]
+}
+```

--- a/apps/docs/i18n/ru/docusaurus-plugin-content-docs/current/examples/validation-errors.md
+++ b/apps/docs/i18n/ru/docusaurus-plugin-content-docs/current/examples/validation-errors.md
@@ -1,1 +1,113 @@
-> Как структурируются и возвращаются ошибки валидации.
+# Обработка ошибок
+
+При неудачной валидации `bindingCargo` выбрасывает `CargoValidationError`. Вы можете обработать эту ошибку с помощью `setCargoErrorHandler` или встроенного middleware обработки ошибок Express.
+
+---
+
+## Типы ошибок
+
+### `CargoValidationError`
+
+Выбрасывается, когда одно или несколько полей не проходят валидацию.
+
+| Свойство | Тип | Описание |
+|---|---|---|
+| `name` | `string` | Всегда `'CargoValidationError'` |
+| `errors` | `CargoFieldError[]` | Список ошибок по полям |
+
+### `CargoFieldError`
+
+Представляет ошибку валидации одного поля.
+
+| Свойство | Тип | Описание |
+|---|---|---|
+| `name` | `string` | Всегда `'CargoFieldError'` |
+| `field` | `string \| symbol` | Имя поля, не прошедшего валидацию |
+| `message` | `string` | Сообщение об ошибке |
+
+---
+
+## Вариант 1: `setCargoErrorHandler` (Рекомендуется)
+
+Зарегистрируйте глобальный обработчик один раз при запуске приложения. Все ошибки валидации на каждом маршруте будут обрабатываться автоматически.
+
+```typescript
+import { setCargoErrorHandler, CargoValidationError } from 'express-cargo'
+
+setCargoErrorHandler((err, req, res, next) => {
+    res.status(400).json({
+        error: 'Ошибка валидации',
+        details: err.errors.map(e => ({
+            field: e.field,
+            message: e.message,
+        })),
+    })
+})
+```
+
+**Пример ответа:**
+```json
+{
+    "error": "Ошибка валидации",
+    "details": [
+        { "field": "email", "message": "email should be a valid email" },
+        { "field": "age", "message": "age must be >= 0" }
+    ]
+}
+```
+
+---
+
+## Вариант 2: Middleware ошибок Express
+
+Используйте стандартный 4-аргументный middleware ошибок Express для перехвата `CargoValidationError`.
+
+```typescript
+import { CargoValidationError } from 'express-cargo'
+import { Request, Response, NextFunction } from 'express'
+
+app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
+    if (err instanceof CargoValidationError) {
+        return res.status(400).json({
+            error: 'Ошибка валидации',
+            details: err.errors.map(e => ({
+                field: e.field,
+                message: e.message,
+            })),
+        })
+    }
+    next(err)
+})
+```
+
+> **Примечание:** Если `setCargoErrorHandler` зарегистрирован, он имеет приоритет. Middleware ошибок Express получит ошибку только в том случае, если `next(err)` вызван внутри `setCargoErrorHandler`.
+
+---
+
+## Обработка нескольких ошибок
+
+Один запрос может не пройти несколько валидаций одновременно. Все ошибки собираются и возвращаются вместе.
+
+```typescript
+class CreateUserDto {
+    @Body()
+    @Email()
+    email!: string
+
+    @Body()
+    @Min(0)
+    age!: number
+}
+```
+
+Если оба поля невалидны, `err.errors` будет содержать две записи:
+
+```json
+{
+    "error": "Ошибка валидации",
+    "details": [
+        { "field": "email", "message": "email should be a valid email" },
+        { "field": "age", "message": "age must be >= 0" }
+    ]
+}
+```


### PR DESCRIPTION
validation-errors.md와 README의 Error Handling 섹션에 에러 가이드 작성햇습니다.

추가한 내용

1. 에러 타입 설명
CargoValidationError에는 errors 배열이 있고 각 배열 항목은 CargoFieldError인데 
field어떤 필드인지와 message-> 왜 실패했는지를 담고 있다는 걸 표로 정리

2. 사용법 두 가지
setCargoErrorHandler: 앱 시작할 때 한 번 등록하면 모든 라우트에 자동 적용 (**권장**)
Express error middleware: 기존 Express 방식(app.use((err, req, res, next) => ...))으로 잡는 방법

3. 두 방식 관계 설명
둘 다 쓰면 setCargoErrorHandler가 먼저 실행된다는 것 명시

4. 여러 에러 동시 처리
필드 두 개가 동시에 실패하면 err.errors 배열에 두 개가 같이 담겨서 한 번에 응답할 수 있다는 예시

추가로 README의 e.name → e.message 버그를 수정 했습니다.