### PR TITLE
fix: correct transformer output example value in transforms document

### DIFF
--- a/apps/docs/docs/decorators/transforms.md
+++ b/apps/docs/docs/decorators/transforms.md
@@ -45,7 +45,6 @@ app.get('/search', bindingCargo(SearchRequest), (req: Request, res: Response) =>
         // Verify the type of the transformed data
         sortByType: typeof searchParams.sortBy,
         countType: typeof searchParams.count,
-        doubleCount: searchParams.count,
     })
 })
 
@@ -66,10 +65,9 @@ When the example request URL is accessed, the `bindingCargo` middleware processe
     "message": "Search parameters transformed successfully!", 
     "data": {
         "sortBy": "title",
-        "count": 10
+        "count": 20
     },
     "sortByType": "string",
-    "countType": "number",
-    "doubleCount": 10
+    "countType": "number"
 }
 ```

--- a/apps/docs/i18n/de/docusaurus-plugin-content-docs/current/decorators/transforms.md
+++ b/apps/docs/i18n/de/docusaurus-plugin-content-docs/current/decorators/transforms.md
@@ -45,7 +45,6 @@ app.get('/search', bindingCargo(SearchRequest), (req: Request, res: Response) =>
         // Überprüfen Sie den Typ der transformierten Daten
         sortByType: typeof searchParams.sortBy,
         countType: typeof searchParams.count,
-        doubleCount: searchParams.count,
     })
 })
 
@@ -66,10 +65,9 @@ Wenn auf die Beispiel-Anfrage-URL zugegriffen wird, verarbeitet die `bindingCarg
     "message": "Suchparameter erfolgreich transformiert!", 
     "data": {
         "sortBy": "title",
-        "count": 10
+        "count": 20
     },
     "sortByType": "string",
-    "countType": "number",
-    "doubleCount": 10
+    "countType": "number"
 }
 ```

--- a/apps/docs/i18n/fr/docusaurus-plugin-content-docs/current/decorators/transforms.md
+++ b/apps/docs/i18n/fr/docusaurus-plugin-content-docs/current/decorators/transforms.md
@@ -45,7 +45,6 @@ app.get('/search', bindingCargo(SearchRequest), (req: Request, res: Response) =>
         // Vérifier le type des données transformées
         sortByType: typeof searchParams.sortBy,
         countType: typeof searchParams.count,
-        doubleCount: searchParams.count,
     })
 })
 
@@ -66,10 +65,9 @@ Lorsque l'URL de requête d'exemple est accédée, le middleware `bindingCargo` 
     "message": "Paramètres de recherche transformés avec succès !",
     "data": {
         "sortBy": "title",
-        "count": 10
+        "count": 20
     },
     "sortByType": "string",
-    "countType": "number",
-    "doubleCount": 10
+    "countType": "number"
 }
 ```

--- a/apps/docs/i18n/ja/docusaurus-plugin-content-docs/current/decorators/transforms.md
+++ b/apps/docs/i18n/ja/docusaurus-plugin-content-docs/current/decorators/transforms.md
@@ -45,7 +45,6 @@ app.get('/search', bindingCargo(SearchRequest), (req: Request, res: Response) =>
         // 変換されたデータの型を確認
         sortByType: typeof searchParams.sortBy,
         countType: typeof searchParams.count,
-        doubleCount: searchParams.count,
     })
 })
 
@@ -66,10 +65,9 @@ http://localhost:3000/search?sortBy=TITLE&count=10
     "message": "Search parameters transformed successfully!", 
     "data": {
         "sortBy": "title",
-        "count": 10
+        "count": 20
     },
     "sortByType": "string",
-    "countType": "number",
-    "doubleCount": 10
+    "countType": "number"
 }
 ```

--- a/apps/docs/i18n/ko/docusaurus-plugin-content-docs/current/decorators/transforms.md
+++ b/apps/docs/i18n/ko/docusaurus-plugin-content-docs/current/decorators/transforms.md
@@ -50,7 +50,6 @@ app.get('/search', bindingCargo(SearchRequest), (req: Request, res: Response) =>
         // 변환된 데이터와 그 타입 확인
         sortByType: typeof searchParams.sortBy,
         countType: typeof searchParams.count,
-        doubleCount: searchParams.count,
     })
 })
 
@@ -71,10 +70,9 @@ http://localhost:3000/search?sortBy=TITLE&count=10
     "message": "Search parameters transformed successfully!",
     "data": {
         "sortBy": "title",
-        "count": 10
+        "count": 20
     },
     "sortByType": "string",
-    "countType": "number",
-    "doubleCount": 10
+    "countType": "number"
 }
 ```

--- a/apps/docs/i18n/ru/docusaurus-plugin-content-docs/current/decorators/transforms.md
+++ b/apps/docs/i18n/ru/docusaurus-plugin-content-docs/current/decorators/transforms.md
@@ -44,7 +44,7 @@ app.get('/search', bindingCargo(SearchRequest), (req: Request, res: Response) =>
         data: searchParams,
         // Проверьте тип преобразованных данных
         sortByType: typeof searchParams.sortBy,
-        countType: typeof searchParams.count
+        countType: typeof searchParams.count,
     })
 })
 

--- a/apps/docs/i18n/ru/docusaurus-plugin-content-docs/current/decorators/transforms.md
+++ b/apps/docs/i18n/ru/docusaurus-plugin-content-docs/current/decorators/transforms.md
@@ -44,8 +44,7 @@ app.get('/search', bindingCargo(SearchRequest), (req: Request, res: Response) =>
         data: searchParams,
         // Проверьте тип преобразованных данных
         sortByType: typeof searchParams.sortBy,
-        countType: typeof searchParams.count,
-        doubleCount: searchParams.count,
+        countType: typeof searchParams.count
     })
 })
 
@@ -66,10 +65,9 @@ http://localhost:3000/search?sortBy=TITLE&count=10
     "message": "Параметры поиска успешно преобразованы!", 
     "data": {
         "sortBy": "title",
-        "count": 10
+        "count": 20
     },
     "sortByType": "string",
-    "countType": "number",
-    "doubleCount": 10
+    "countType": "number"
 }
 ```


### PR DESCRIPTION
#214 에서 발견된 이슈로, `transform` 데코레이터 문서에 예시 출력 예제의 값이 실제 출력과 다른 버그를 수정합니다.
또한, 주석 설명에 따라 아래 `doubleCount` 리턴을 제거함으로써 주석설명을 실제 반환 값이 좀 더 명확하게 표현될 수 있도록 반영하였습니다.