### PR TITLE
refactor: clean up cache handling in CargoClassMetadata

### DIFF
--- a/packages/express-cargo/src/binding.ts
+++ b/packages/express-cargo/src/binding.ts
@@ -187,7 +187,6 @@ function typeCasting(
     if (isClass(targetClass) && typeof value === 'object' && value !== null) {
         const nextSources = { ...sources, [currentSource]: value }
         const nestedMeta = new CargoClassMetadata(targetClass.prototype)
-        nestedMeta.markBindingCargoCalled()
         return bindObject(targetClass, nestedMeta, nextSources, errors, getErrorKey(sourceKey, key))
     }
 
@@ -323,7 +322,6 @@ function bindVirtual({ metaClass, targetObject, errors, sourceKey }: BindContext
  */
 export function bindingCargo<T extends object = any>(cargoClass: new () => T): RequestHandler {
     const metaClass = new CargoClassMetadata(cargoClass.prototype)
-    metaClass.markBindingCargoCalled()
 
     return (req, res, next) => {
         try {

--- a/packages/express-cargo/src/binding.ts
+++ b/packages/express-cargo/src/binding.ts
@@ -186,7 +186,7 @@ function typeCasting(
     // Recursive binding: Transform nested plain objects into class instances
     if (isClass(targetClass) && typeof value === 'object' && value !== null) {
         const nextSources = { ...sources, [currentSource]: value }
-        const nestedMeta = new CargoClassMetadata(targetClass.prototype)
+        const nestedMeta = new CargoClassMetadata(targetClass.prototype, true)
         return bindObject(targetClass, nestedMeta, nextSources, errors, getErrorKey(sourceKey, key))
     }
 
@@ -321,7 +321,7 @@ function bindVirtual({ metaClass, targetObject, errors, sourceKey }: BindContext
  * ```
  */
 export function bindingCargo<T extends object = any>(cargoClass: new () => T): RequestHandler {
-    const metaClass = new CargoClassMetadata(cargoClass.prototype)
+    const metaClass = new CargoClassMetadata(cargoClass.prototype, true)
 
     return (req, res, next) => {
         try {

--- a/packages/express-cargo/src/metadata.ts
+++ b/packages/express-cargo/src/metadata.ts
@@ -7,11 +7,10 @@ import { Source, TypeOptions, TypeResolver, TypeThunk, validArrayElementType, Va
  * Handles field registration, retrieval, and caching of metadata.
  */
 export class CargoClassMetadata {
-    private target: any
-
-    constructor(target: any) {
-        this.target = target
-    }
+    constructor(
+        private target: any,
+        private cacheable: boolean = false,
+    ) {}
 
     getMetadataKey(propertyKey: string | symbol): string {
         return `cargo:${String(propertyKey)}`
@@ -44,9 +43,10 @@ export class CargoClassMetadata {
     }
 
     private getFieldListByKey(metadataKey: string): (string | symbol)[] {
-        const cacheKey = this.getCacheKey(metadataKey)
-        const cached = Reflect.getMetadata(cacheKey, this.target)
-        if (cached) return cached
+        if (this.cacheable) {
+            const cached = Reflect.getMetadata(this.getCacheKey(metadataKey), this.target)
+            if (cached) return cached
+        }
 
         const fields = new Set<string | symbol>()
         let current = this.target
@@ -57,7 +57,11 @@ export class CargoClassMetadata {
         }
 
         const fieldList = Array.from(fields)
-        Reflect.defineMetadata(cacheKey, fieldList, this.target)
+
+        // flag가 true일 때만 캐싱
+        if (this.cacheable) {
+            Reflect.defineMetadata(this.getCacheKey(metadataKey), fieldList, this.target)
+        }
 
         return fieldList
     }
@@ -66,7 +70,10 @@ export class CargoClassMetadata {
         const existing = this.getFieldListByKey(metadataKey)
         if (!existing.includes(propertyKey)) {
             Reflect.defineMetadata(metadataKey, [...existing, propertyKey], this.target)
-            Reflect.deleteMetadata(this.getCacheKey(metadataKey), this.target)
+
+            if (this.cacheable) {
+                Reflect.deleteMetadata(this.getCacheKey(metadataKey), this.target)
+            }
         }
     }
 

--- a/packages/express-cargo/src/metadata.ts
+++ b/packages/express-cargo/src/metadata.ts
@@ -8,7 +8,6 @@ import { Source, TypeOptions, TypeResolver, TypeThunk, validArrayElementType, Va
  */
 export class CargoClassMetadata {
     private target: any
-    private metadataFinalized: boolean = false
 
     constructor(target: any) {
         this.target = target
@@ -34,10 +33,6 @@ export class CargoClassMetadata {
         return `__cache__${metadataKey}`
     }
 
-    markBindingCargoCalled() {
-        this.metadataFinalized = true
-    }
-
     getFieldMetadata(propertyKey: string | symbol): CargoFieldMetadata {
         const metadataKey = this.getMetadataKey(propertyKey)
         return Reflect.getMetadata(metadataKey, this.target) || new CargoFieldMetadata(this.target, propertyKey)
@@ -49,10 +44,9 @@ export class CargoClassMetadata {
     }
 
     private getFieldListByKey(metadataKey: string): (string | symbol)[] {
-        if (this.metadataFinalized) {
-            const cached = Reflect.getMetadata(this.getCacheKey(metadataKey), this.target)
-            if (cached) return cached
-        }
+        const cacheKey = this.getCacheKey(metadataKey)
+        const cached = Reflect.getMetadata(cacheKey, this.target)
+        if (cached) return cached
 
         const fields = new Set<string | symbol>()
         let current = this.target
@@ -63,11 +57,7 @@ export class CargoClassMetadata {
         }
 
         const fieldList = Array.from(fields)
-
-        // flag가 true일 때만 캐싱
-        if (this.metadataFinalized) {
-            Reflect.defineMetadata(this.getCacheKey(metadataKey), fieldList, this.target)
-        }
+        Reflect.defineMetadata(cacheKey, fieldList, this.target)
 
         return fieldList
     }
@@ -76,10 +66,7 @@ export class CargoClassMetadata {
         const existing = this.getFieldListByKey(metadataKey)
         if (!existing.includes(propertyKey)) {
             Reflect.defineMetadata(metadataKey, [...existing, propertyKey], this.target)
-
-            if (this.metadataFinalized) {
-                Reflect.deleteMetadata(this.getCacheKey(metadataKey), this.target)
-            }
+            Reflect.deleteMetadata(this.getCacheKey(metadataKey), this.target)
         }
     }
 


### PR DESCRIPTION
## 배경

`CargoClassMetadata`에는 메타데이터 캐싱이 안전한 시점인지 확인하는 `metadataFinalized` 플래그와 이를 켜는 `markBindingCargoCalled` 메서드가 있습니다. 본래 의도는 데코레이터 등록이 끝나기 전에 캐시가 만들어져 이후 추가되는 필드가 누락되는 상황을 방지하기 위함이라고 인지하였습니다.

## 작업 동기

코드를 살펴보던 중, `markBindingCargoCalled`가 런타임의 `bindingCargo` 및 `bindObject` 내부에서 `CargoClassMetadata` 인스턴스를 생성한 직후 항상 호출되고 있음을 확인하였습니다. 

즉 인스턴스의 사용 모드(데코레이터용 vs런타임용)가 생성 시점에 이미 결정되어 있음에도, 별도의 setter 메서드로
상태를 전환하는 방식으로 표현되어 있어 다음과 같은 개선 여지가 있다고 판단하였습니다.

1. `markBindingCargoCalled`라는 메서드명은 동작 기반이라 의도가 직관적으로 드러나지 않음
2. 생성 후 setter 호출까지의 시간차에 잘못된 사용이 끼어들 여지가 있음
3. 사용 모드가 가변 상태로 표현되어 있어 정신 모델이 복잡함

## 변경 방향

캐싱 가능 여부를 생성자 매개변수로 전달하여 객체 생성 시점에 모드가
확정되도록 변경합니다.

```ts
// AS-IS
const metaClass = new CargoClassMetadata(cargoClass.prototype)
metaClass.markBindingCargoCalled()

// TO-BE
const metaClass = new CargoClassMetadata(cargoClass.prototype, true)
```

데코레이터 경로는 기본값(`false`)을 사용하므로 호출부 변경이 필요하지
않습니다.

## 변경 사항

- `CargoClassMetadata` 생성자에 `cacheable: boolean = false` 매개변수 추가
- `metadataFinalized` 필드를 `cacheable`로 대체 (의미 명확화)
- `markBindingCargoCalled` 메서드 제거
- `bindingCargo`, `bindObject`에서 인스턴스 생성 시 `true` 전달

## 영향 범위

- 외부 API 변경 없음 (데코레이터에서 사용하는 호출 시그니처 동일)
- 동작 동일