### PR TITLE
feat: make getCargo return T and throw when binding middleware is missing

### DIFF
--- a/packages/express-cargo/src/binding.ts
+++ b/packages/express-cargo/src/binding.ts
@@ -345,8 +345,13 @@ export function bindingCargo<T extends object = any>(cargoClass: new () => T): R
  * Retrieves the bound cargo object from the request.
  *
  * @param req - The Express Request object.
- * @returns The bound class instance, or undefined if not found.
+ * @returns The bound class instance.
+ * @throws If the binding middleware has not run for this request.
  */
-export function getCargo<T extends object>(req: Request): T | undefined {
-    return req._cargo as T
+export function getCargo<T extends object>(req: Request): T {
+    const cargo = req._cargo
+    if (cargo === undefined) {
+        throw new Error('Cargo not found on the request. Register the bindingCargo() middleware on this route before calling getCargo().')
+    }
+    return cargo as T
 }

--- a/packages/express-cargo/src/binding.ts
+++ b/packages/express-cargo/src/binding.ts
@@ -350,7 +350,7 @@ export function bindingCargo<T extends object = any>(cargoClass: new () => T): R
  */
 export function getCargo<T extends object>(req: Request): T {
     const cargo = req._cargo
-    if (cargo === undefined) {
+    if (cargo == null) {
         throw new Error('Cargo not found on the request. Register the bindingCargo() middleware on this route before calling getCargo().')
     }
     return cargo as T

--- a/packages/express-cargo/tests/binding/requestBinding.test.ts
+++ b/packages/express-cargo/tests/binding/requestBinding.test.ts
@@ -109,6 +109,11 @@ describe('request binding', () => {
         expect(() => getCargo<RequestDTO>(req)).toThrow(/bindingCargo/)
     })
 
+    it('_cargo가 null이어도 getCargo는 에러를 던진다', () => {
+        const req = makeMockReq({ _cargo: null } as any)
+        expect(() => getCargo<RequestDTO>(req)).toThrow(/bindingCargo/)
+    })
+
     it('required request field가 없으면 validator를 건너뛴다', () => {
         const middleware = bindingCargo(RequiredRequestDTO)
 

--- a/packages/express-cargo/tests/binding/requestBinding.test.ts
+++ b/packages/express-cargo/tests/binding/requestBinding.test.ts
@@ -104,6 +104,11 @@ describe('request binding', () => {
         expect(() => bindingCargo(MixedBindingDTO)).toThrow(CargoSchemaError)
     })
 
+    it('bindingCargo 미들웨어 없이 getCargo를 호출하면 에러를 던진다', () => {
+        const req = makeMockReq()
+        expect(() => getCargo<RequestDTO>(req)).toThrow(/bindingCargo/)
+    })
+
     it('required request field가 없으면 validator를 건너뛴다', () => {
         const middleware = bindingCargo(RequiredRequestDTO)
 


### PR DESCRIPTION
논의 결과에 따라 getCargo가 undefined를 리턴하지 않도록 수정하고, 만약 bindingCargo가 실행되지 않은 상태로 실행되게 된다면 오류를 반환하도록 수정하였습니다.