### PR TITLE
refactor: separate class analysis and rule validation logic

### DIFF
--- a/packages/express-cargo/src/analysis.ts
+++ b/packages/express-cargo/src/analysis.ts
@@ -77,7 +77,8 @@ export function analyzeCargoSchema(cargoClass: ClassConstructor): AnalysisResult
         visited.add(currentClass)
 
         // Metadata is collected once per class and shared across all contexts.
-        const classMeta = new CargoClassMetadata(currentClass.prototype, true)
+        const prototype = currentClass.prototype
+        const classMeta = new CargoClassMetadata(prototype && typeof prototype === 'object' ? prototype : {}, true)
         metadataMap.set(currentClass, classMeta)
 
         for (const nested of collectNestedClasses(classMeta)) {

--- a/packages/express-cargo/src/analysis.ts
+++ b/packages/express-cargo/src/analysis.ts
@@ -27,7 +27,7 @@ function collectNestedClasses(classMeta: CargoClassMetadata): ClassConstructor[]
             // (ES6 class can't be invoked without `new`), so handle it before the Thunk path.
             if (isValidatableClass(typeFn)) {
                 nested.push(typeFn)
-            } else {
+            } else if (typeFn.length === 0) {
                 // @Type(() => Foo) — Thunk form. Resolver form (`(data) => Foo`) can't be
                 // evaluated statically and will throw on the no-arg call; we catch and skip.
                 try {

--- a/packages/express-cargo/src/analysis.ts
+++ b/packages/express-cargo/src/analysis.ts
@@ -54,6 +54,10 @@ const ANALYSIS_CACHE = new WeakMap<ClassConstructor, AnalysisResult>()
  * This function caches its results, so subsequent calls for the same class are free.
  */
 export function analyzeCargoSchema(cargoClass: ClassConstructor): AnalysisResult {
+    if (typeof cargoClass !== 'function') {
+        throw new TypeError(`analyzeCargoSchema expects a class constructor, but received ${cargoClass === null ? 'null' : typeof cargoClass}.`)
+    }
+
     const cached = ANALYSIS_CACHE.get(cargoClass)
     if (cached) return cached
 

--- a/packages/express-cargo/src/analysis.ts
+++ b/packages/express-cargo/src/analysis.ts
@@ -1,0 +1,96 @@
+import { CargoClassMetadata } from './metadata'
+import { AnalysisResult, ClassConstructor, TypeThunk } from './types'
+import { isClass } from './utils'
+
+// `Object` is included because reflect-metadata falls back to it for unresolvable
+// design:type entries; `Array` guards against a malformed `@List(Array)`.
+// Both pass the isClass heuristic but should never be descended into.
+const PRIMITIVE_TYPES = new Set<unknown>([String, Number, Boolean, Date, Object, Array])
+
+/** A value is safe to traverse during schema validation only if it's a class (heuristic) and not a primitive constructor. */
+function isValidatableClass(value: unknown): value is ClassConstructor {
+    return isClass(value) && !PRIMITIVE_TYPES.has(value)
+}
+
+/**
+ * Walks the `@Type` / `@List` references on a class's fields and yields every nested class that should also be validated.
+ */
+function collectNestedClasses(classMeta: CargoClassMetadata): ClassConstructor[] {
+    const nested: ClassConstructor[] = []
+
+    for (const propertyKey of classMeta.getAllFieldsList()) {
+        const fieldMeta = classMeta.getFieldMetadata(propertyKey)
+
+        const typeFn = fieldMeta.getTypeFn()
+        if (typeFn) {
+            // @Type(User) — class passed directly. Calling it as a Thunk would throw
+            // (ES6 class can't be invoked without `new`), so handle it before the Thunk path.
+            if (isValidatableClass(typeFn)) {
+                nested.push(typeFn)
+            } else {
+                // @Type(() => Foo) — Thunk form. Resolver form (`(data) => Foo`) can't be
+                // evaluated statically and will throw on the no-arg call; we catch and skip.
+                try {
+                    const result = (typeFn as TypeThunk)()
+                    if (isValidatableClass(result)) nested.push(result)
+                } catch {
+                    // Resolver-shaped functions need runtime data; ignore.
+                }
+            }
+
+            // Discriminator subTypes are static — but still guard against malformed entries.
+            const options = fieldMeta.getTypeOptions()
+            if (options?.discriminator) {
+                for (const sub of options.discriminator.subTypes) {
+                    if (isValidatableClass(sub.value)) nested.push(sub.value)
+                }
+            }
+        }
+
+        // @List(Foo) / array element type set by @Type-on-array.
+        const elementType = fieldMeta.getArrayElementType()
+        if (isValidatableClass(elementType)) nested.push(elementType)
+    }
+
+    return nested
+}
+
+const ANALYSIS_CACHE = new WeakMap<ClassConstructor, AnalysisResult>()
+
+/**
+ * Recursively analyzes a cargo class and all its nested DTOs.
+ * Returns an AnalysisResult containing metadata for all discovered classes.
+ *
+ * This function caches its results, so subsequent calls for the same class are free.
+ */
+export function analyzeCargoSchema(cargoClass: ClassConstructor): AnalysisResult {
+    const cached = ANALYSIS_CACHE.get(cargoClass)
+    if (cached) return cached
+
+    const metadataMap = new Map<ClassConstructor, CargoClassMetadata>()
+    const visited = new Set<ClassConstructor>()
+    const stack: ClassConstructor[] = [cargoClass]
+
+    while (stack.length > 0) {
+        const currentClass = stack.pop() as ClassConstructor
+        if (visited.has(currentClass)) continue
+        visited.add(currentClass)
+
+        // Metadata is collected once per class and shared across all contexts.
+        const classMeta = new CargoClassMetadata(currentClass.prototype, true)
+        metadataMap.set(currentClass, classMeta)
+
+        for (const nested of collectNestedClasses(classMeta)) {
+            if (!visited.has(nested)) stack.push(nested)
+        }
+    }
+
+    const result: AnalysisResult = {
+        rootClass: cargoClass,
+        rootMeta: metadataMap.get(cargoClass)!,
+        metadataMap,
+    }
+
+    ANALYSIS_CACHE.set(cargoClass, result)
+    return result
+}

--- a/packages/express-cargo/src/analysis.ts
+++ b/packages/express-cargo/src/analysis.ts
@@ -77,8 +77,10 @@ export function analyzeCargoSchema(cargoClass: ClassConstructor): AnalysisResult
         visited.add(currentClass)
 
         // Metadata is collected once per class and shared across all contexts.
+        // resolve() precomputes the merged field lists here, after decoration is complete,
+        // so binding-time reads never walk the prototype chain.
         const prototype = currentClass.prototype
-        const classMeta = new CargoClassMetadata(prototype && typeof prototype === 'object' ? prototype : {}, true)
+        const classMeta = new CargoClassMetadata(prototype && typeof prototype === 'object' ? prototype : {}).resolve()
         metadataMap.set(currentClass, classMeta)
 
         for (const nested of collectNestedClasses(classMeta)) {

--- a/packages/express-cargo/src/analysis.ts
+++ b/packages/express-cargo/src/analysis.ts
@@ -1,16 +1,6 @@
 import { CargoClassMetadata } from './metadata'
 import { AnalysisResult, ClassConstructor, TypeThunk } from './types'
-import { isClass } from './utils'
-
-// `Object` is included because reflect-metadata falls back to it for unresolvable
-// design:type entries; `Array` guards against a malformed `@List(Array)`.
-// Both pass the isClass heuristic but should never be descended into.
-const PRIMITIVE_TYPES = new Set<unknown>([String, Number, Boolean, Date, Object, Array])
-
-/** A value is safe to traverse during schema validation only if it's a class (heuristic) and not a primitive constructor. */
-function isValidatableClass(value: unknown): value is ClassConstructor {
-    return isClass(value) && !PRIMITIVE_TYPES.has(value)
-}
+import { isUserDefinedClass } from './utils'
 
 /**
  * Walks the `@Type` / `@List` references on a class's fields and yields every nested class that should also be validated.
@@ -25,14 +15,14 @@ function collectNestedClasses(classMeta: CargoClassMetadata): ClassConstructor[]
         if (typeFn) {
             // @Type(User) — class passed directly. Calling it as a Thunk would throw
             // (ES6 class can't be invoked without `new`), so handle it before the Thunk path.
-            if (isValidatableClass(typeFn)) {
+            if (isUserDefinedClass(typeFn)) {
                 nested.push(typeFn)
             } else if (typeFn.length === 0) {
                 // @Type(() => Foo) — Thunk form. Resolver form (`(data) => Foo`) can't be
                 // evaluated statically and will throw on the no-arg call; we catch and skip.
                 try {
                     const result = (typeFn as TypeThunk)()
-                    if (isValidatableClass(result)) nested.push(result)
+                    if (isUserDefinedClass(result)) nested.push(result)
                 } catch {
                     // Resolver-shaped functions need runtime data; ignore.
                 }
@@ -42,14 +32,14 @@ function collectNestedClasses(classMeta: CargoClassMetadata): ClassConstructor[]
             const options = fieldMeta.getTypeOptions()
             if (options?.discriminator) {
                 for (const sub of options.discriminator.subTypes) {
-                    if (isValidatableClass(sub.value)) nested.push(sub.value)
+                    if (isUserDefinedClass(sub.value)) nested.push(sub.value)
                 }
             }
         }
 
         // @List(Foo) / array element type set by @Type-on-array.
         const elementType = fieldMeta.getArrayElementType()
-        if (isValidatableClass(elementType)) nested.push(elementType)
+        if (isUserDefinedClass(elementType)) nested.push(elementType)
     }
 
     return nested

--- a/packages/express-cargo/src/binding.ts
+++ b/packages/express-cargo/src/binding.ts
@@ -170,7 +170,7 @@ function typeCasting(
     }
 
     // Recursive binding: Transform nested plain objects into class instances
-    if (isClass(targetClass) && typeof value === 'object' && value !== null) {
+    if (isClass(targetClass) && targetClass !== Object && typeof value === 'object' && value !== null) {
         const nextSources = { ...sources, [currentSource]: value }
         const nestedMetaFromMap = analysis.metadataMap.get(targetClass)
         let targetAnalysis = analysis

--- a/packages/express-cargo/src/binding.ts
+++ b/packages/express-cargo/src/binding.ts
@@ -1,11 +1,12 @@
 import type { Request, RequestHandler } from 'express'
 
-import { BindContext, BindSources } from './types'
+import { AnalysisResult, BindContext, BindSources, ClassConstructor } from './types'
 import { CargoFieldError, CargoValidationError, CargoTransformFieldError, Source, TypeResolver, TypeThunk, TypeOptions } from './types'
 import { CargoClassMetadata, CargoFieldMetadata } from './metadata'
 import { getCargoErrorHandler } from './errorHandler'
-import { validateCargoSchema } from './rules'
+import { validateAnalysis } from './rules/validate'
 import { isClass } from './utils'
+import { analyzeCargoSchema } from './analysis'
 
 function getErrorKey(sourceKey: string, currentKey: string): string {
     return sourceKey ? `${sourceKey}.${currentKey}` : currentKey
@@ -69,11 +70,12 @@ function transformSource(
     sources: BindSources,
     sourceKey: string,
     currentSource: Source,
+    analysis: AnalysisResult,
 ): void {
     if (meta.getEnumType() !== undefined) {
         targetObject[property] = value
     } else {
-        targetObject[property] = typeCasting(meta.type, meta, sourceKey, key, value, errors, sources, currentSource)
+        targetObject[property] = typeCasting(meta.type, meta, sourceKey, key, value, errors, sources, currentSource, analysis)
     }
 
     const transformer = meta.getTransformer()
@@ -117,6 +119,7 @@ function typeCasting(
     errors: CargoFieldError[],
     sources: any,
     currentSource: Source,
+    analysis: AnalysisResult,
 ): any {
     // Handle Array types: Recursively process each element
     if (baseType === Array || Array.isArray(value)) {
@@ -130,7 +133,7 @@ function typeCasting(
 
         return value.map((element, i) => {
             // Pass the current meta to support polymorphism for array elements
-            return typeCasting(elementType, meta, sourceKey, `${key}[${i}]`, element, errors, sources, currentSource)
+            return typeCasting(elementType, meta, sourceKey, `${key}[${i}]`, element, errors, sources, currentSource, analysis)
         })
     }
 
@@ -169,15 +172,22 @@ function typeCasting(
     // Recursive binding: Transform nested plain objects into class instances
     if (isClass(targetClass) && typeof value === 'object' && value !== null) {
         const nextSources = { ...sources, [currentSource]: value }
-        const nestedMeta = new CargoClassMetadata(targetClass.prototype, true)
-        return bindObject(targetClass, nestedMeta, nextSources, errors, getErrorKey(sourceKey, key))
+        const nestedMeta = analysis.metadataMap.get(targetClass) || new CargoClassMetadata(targetClass.prototype, true)
+        return bindObject(targetClass, nestedMeta, nextSources, errors, analysis, getErrorKey(sourceKey, key))
     }
 
     // Fallback: Return raw value if no further transformation is possible
     return value
 }
 
-function bindObject(objectClass: any, metaClass: CargoClassMetadata, sources: BindSources, errors: CargoFieldError[], sourceKey: string = ''): any {
+function bindObject(
+    objectClass: any,
+    metaClass: CargoClassMetadata,
+    sources: BindSources,
+    errors: CargoFieldError[],
+    analysis: AnalysisResult,
+    sourceKey: string = '',
+): any {
     const targetObject = new objectClass()
     const context: BindContext = {
         metaClass,
@@ -188,7 +198,7 @@ function bindObject(objectClass: any, metaClass: CargoClassMetadata, sources: Bi
     }
 
     bindRequest(context)
-    bindSource(context)
+    bindSource(context, analysis)
     bindVirtual(context)
 
     return targetObject
@@ -228,7 +238,7 @@ function bindRequest({ metaClass, targetObject, sources, errors, sourceKey }: Bi
     }
 }
 
-function bindSource({ metaClass, targetObject, sources, errors, sourceKey }: BindContext): void {
+function bindSource({ metaClass, targetObject, sources, errors, sourceKey }: BindContext, analysis: AnalysisResult): void {
     for (const property of metaClass.getFieldList()) {
         const meta = metaClass.getFieldMetadata(property)
         if (meta.getRequestTransformer()) continue
@@ -250,7 +260,7 @@ function bindSource({ metaClass, targetObject, sources, errors, sourceKey }: Bin
             continue
         }
 
-        transformSource(meta, property, key, value, targetObject, errors, sources, sourceKey, currentSource)
+        transformSource(meta, property, key, value, targetObject, errors, sources, sourceKey, currentSource, analysis)
         validateField(meta, property, targetObject, errors)
     }
 }
@@ -303,12 +313,10 @@ function bindVirtual({ metaClass, targetObject, errors, sourceKey }: BindContext
  * });
  * ```
  */
-export function bindingCargo<T extends object = any>(cargoClass: new () => T): RequestHandler {
+export function bindingCargo<T extends object = any>(cargoClass: ClassConstructor<T>): RequestHandler {
     // Fail fast on schema mistakes at route-registration time instead of on the first request.
-    // `validateCargoSchema` caches its result, so repeat calls for the same class are essentially free.
-    validateCargoSchema(cargoClass)
-
-    const metaClass = new CargoClassMetadata(cargoClass.prototype, true)
+    const result = analyzeCargoSchema(cargoClass)
+    validateAnalysis(result)
 
     return (req, res, next) => {
         try {
@@ -321,7 +329,7 @@ export function bindingCargo<T extends object = any>(cargoClass: new () => T): R
                 header: req.headers,
                 session: (req as any).session,
             }
-            const cargo = bindObject(cargoClass, metaClass, sources, errors)
+            const cargo = bindObject(cargoClass, result.rootMeta, sources, errors, result)
 
             if (errors.length > 0) {
                 throw new CargoValidationError(errors)

--- a/packages/express-cargo/src/binding.ts
+++ b/packages/express-cargo/src/binding.ts
@@ -172,8 +172,11 @@ function typeCasting(
     // Recursive binding: Transform nested plain objects into class instances
     if (isClass(targetClass) && typeof value === 'object' && value !== null) {
         const nextSources = { ...sources, [currentSource]: value }
-        const nestedMeta = analysis.metadataMap.get(targetClass) || new CargoClassMetadata(targetClass.prototype, true)
-        return bindObject(targetClass, nestedMeta, nextSources, errors, analysis, getErrorKey(sourceKey, key))
+        const nestedMetaFromMap = analysis.metadataMap.get(targetClass)
+        const targetAnalysis = nestedMetaFromMap ? analysis : analyzeCargoSchema(targetClass)
+        const nestedMeta = nestedMetaFromMap || targetAnalysis.rootMeta
+
+        return bindObject(targetClass, nestedMeta, nextSources, errors, targetAnalysis, getErrorKey(sourceKey, key))
     }
 
     // Fallback: Return raw value if no further transformation is possible

--- a/packages/express-cargo/src/binding.ts
+++ b/packages/express-cargo/src/binding.ts
@@ -4,8 +4,8 @@ import { AnalysisResult, BindContext, BindSources, ClassConstructor } from './ty
 import { CargoFieldError, CargoValidationError, CargoTransformFieldError, Source, TypeResolver, TypeThunk, TypeOptions } from './types'
 import { CargoClassMetadata, CargoFieldMetadata } from './metadata'
 import { getCargoErrorHandler } from './errorHandler'
-import { validateAnalysis } from './rules/validate'
-import { isClass } from './utils'
+import { validateAnalysis } from './rules'
+import { isClass, isUserDefinedClass } from './utils'
 import { analyzeCargoSchema } from './analysis'
 
 function getErrorKey(sourceKey: string, currentKey: string): string {
@@ -170,7 +170,7 @@ function typeCasting(
     }
 
     // Recursive binding: Transform nested plain objects into class instances
-    if (isClass(targetClass) && targetClass !== Object && typeof value === 'object' && value !== null) {
+    if (isUserDefinedClass(targetClass) && typeof value === 'object' && value !== null) {
         const nextSources = { ...sources, [currentSource]: value }
         const nestedMetaFromMap = analysis.metadataMap.get(targetClass)
         let targetAnalysis = analysis

--- a/packages/express-cargo/src/binding.ts
+++ b/packages/express-cargo/src/binding.ts
@@ -173,7 +173,11 @@ function typeCasting(
     if (isClass(targetClass) && typeof value === 'object' && value !== null) {
         const nextSources = { ...sources, [currentSource]: value }
         const nestedMetaFromMap = analysis.metadataMap.get(targetClass)
-        const targetAnalysis = nestedMetaFromMap ? analysis : analyzeCargoSchema(targetClass)
+        let targetAnalysis = analysis
+        if (!nestedMetaFromMap) {
+            targetAnalysis = analyzeCargoSchema(targetClass)
+            validateAnalysis(targetAnalysis)
+        }
         const nestedMeta = nestedMetaFromMap || targetAnalysis.rootMeta
 
         return bindObject(targetClass, nestedMeta, nextSources, errors, targetAnalysis, getErrorKey(sourceKey, key))

--- a/packages/express-cargo/src/metadata.ts
+++ b/packages/express-cargo/src/metadata.ts
@@ -1,16 +1,43 @@
 import 'reflect-metadata'
 import type { Request } from 'express'
-import { AppliedDecorator, DecoratorScope, Source, TypeOptions, TypeResolver, TypeThunk, validArrayElementType, ValidatorRule } from './types'
+import {
+    AppliedDecorator,
+    DecoratorScope,
+    ResolvedFieldLists,
+    Source,
+    TypeOptions,
+    TypeResolver,
+    TypeThunk,
+    validArrayElementType,
+    ValidatorRule,
+} from './types'
 
 /**
  * Manages metadata for a cargo class.
- * Handles field registration, retrieval, and caching of metadata.
+ * Handles field registration and retrieval; call {@link CargoClassMetadata.resolve}
+ * to precompute the merged field lists once decoration is complete.
  */
 export class CargoClassMetadata {
-    constructor(
-        private target: any,
-        private cacheable: boolean = false,
-    ) {}
+    private resolved?: ResolvedFieldLists
+
+    constructor(private target: any) {}
+
+    /**
+     * Precomputes every merged field list once and stores the result on this instance.
+     *
+     * Call this after decoration is complete (i.e. during {@link analyzeCargoSchema}); from then on
+     * the read accessors return the precomputed lists instead of walking the prototype chain.
+     * Because the schema is frozen by analysis time, no cache invalidation is needed.
+     */
+    resolve(): this {
+        this.resolved = {
+            fields: this.getFieldListByKey(this.getFieldKey()),
+            requestFields: this.getFieldListByKey(this.getRequestFieldKey()),
+            virtualFields: this.getFieldListByKey(this.getVirtualFieldKey()),
+            allFields: this.getFieldListByKey(this.getAllFieldsKey()),
+        }
+        return this
+    }
 
     getMetadataKey(propertyKey: string | symbol): string {
         return `cargo:${String(propertyKey)}`
@@ -32,10 +59,6 @@ export class CargoClassMetadata {
         return 'cargo:allFields'
     }
 
-    private getCacheKey(metadataKey: string) {
-        return `__cache__${metadataKey}`
-    }
-
     getFieldMetadata(propertyKey: string | symbol): CargoFieldMetadata {
         const metadataKey = this.getMetadataKey(propertyKey)
         return Reflect.getMetadata(metadataKey, this.target) || new CargoFieldMetadata(this.target, propertyKey)
@@ -48,11 +71,6 @@ export class CargoClassMetadata {
     }
 
     private getFieldListByKey(metadataKey: string): (string | symbol)[] {
-        if (this.cacheable) {
-            const cached = Reflect.getOwnMetadata(this.getCacheKey(metadataKey), this.target)
-            if (cached) return cached
-        }
-
         const fields = new Set<string | symbol>()
         let current = this.target
         while (current && current !== Object.prototype) {
@@ -61,29 +79,18 @@ export class CargoClassMetadata {
             current = Object.getPrototypeOf(current)
         }
 
-        const fieldList = Array.from(fields)
-
-        // flag가 true일 때만 캐싱
-        if (this.cacheable) {
-            Reflect.defineMetadata(this.getCacheKey(metadataKey), fieldList, this.target)
-        }
-
-        return fieldList
+        return Array.from(fields)
     }
 
     private setFieldListByKey(metadataKey: string, propertyKey: string | symbol): void {
         const existing = this.getFieldListByKey(metadataKey)
         if (!existing.includes(propertyKey)) {
             Reflect.defineMetadata(metadataKey, [...existing, propertyKey], this.target)
-
-            if (this.cacheable) {
-                Reflect.deleteMetadata(this.getCacheKey(metadataKey), this.target)
-            }
         }
     }
 
     getFieldList(): (string | symbol)[] {
-        return this.getFieldListByKey(this.getFieldKey())
+        return this.resolved?.fields ?? this.getFieldListByKey(this.getFieldKey())
     }
 
     setFieldList(propertyKey: string | symbol): void {
@@ -91,7 +98,7 @@ export class CargoClassMetadata {
     }
 
     getRequestFieldList(): (string | symbol)[] {
-        return this.getFieldListByKey(this.getRequestFieldKey())
+        return this.resolved?.requestFields ?? this.getFieldListByKey(this.getRequestFieldKey())
     }
 
     setRequestFieldList(propertyKey: string | symbol): void {
@@ -99,7 +106,7 @@ export class CargoClassMetadata {
     }
 
     getVirtualFieldList(): (string | symbol)[] {
-        return this.getFieldListByKey(this.getVirtualFieldKey())
+        return this.resolved?.virtualFields ?? this.getFieldListByKey(this.getVirtualFieldKey())
     }
 
     setVirtualFieldList(propertyKey: string | symbol): void {
@@ -107,7 +114,7 @@ export class CargoClassMetadata {
     }
 
     getAllFieldsList(): (string | symbol)[] {
-        return this.getFieldListByKey(this.getAllFieldsKey())
+        return this.resolved?.allFields ?? this.getFieldListByKey(this.getAllFieldsKey())
     }
 }
 

--- a/packages/express-cargo/src/rules/index.ts
+++ b/packages/express-cargo/src/rules/index.ts
@@ -1,1 +1,1 @@
-export { validateCargoSchema } from './validate'
+export { validateAnalysis } from './validate'

--- a/packages/express-cargo/src/rules/validate.ts
+++ b/packages/express-cargo/src/rules/validate.ts
@@ -1,116 +1,37 @@
-import { CargoClassMetadata } from '../metadata'
-import { ClassConstructor, TypeThunk } from '../types'
-import { isClass } from '../utils'
+import { AnalysisResult, ClassConstructor } from '../types'
 import { ACTIVE_CHECKERS } from './registry'
 import { CargoSchemaError } from './errors'
 import { RuleContext, RuleViolation } from './types'
 
-// `Object` is included because reflect-metadata falls back to it for unresolvable
-// design:type entries; `Array` guards against a malformed `@List(Array)`.
-// Both pass the isClass heuristic but should never be descended into.
-const PRIMITIVE_TYPES = new Set<unknown>([String, Number, Boolean, Date, Object, Array])
-
-/** A value is safe to traverse during schema validation only if it's a class (heuristic) and not a primitive constructor. */
-function isValidatableClass(value: unknown): value is ClassConstructor {
-    return isClass(value) && !PRIMITIVE_TYPES.has(value)
-}
-
-/**
- * Walks the `@Type` / `@List` references on a class's fields and yields every nested class that should also be validated.
- */
-function collectNestedClasses(classMeta: CargoClassMetadata): ClassConstructor[] {
-    const nested: ClassConstructor[] = []
-
-    for (const propertyKey of classMeta.getAllFieldsList()) {
-        const fieldMeta = classMeta.getFieldMetadata(propertyKey)
-
-        const typeFn = fieldMeta.getTypeFn()
-        if (typeFn) {
-            // @Type(User) — class passed directly. Calling it as a Thunk would throw
-            // (ES6 class can't be invoked without `new`), so handle it before the Thunk path.
-            if (isValidatableClass(typeFn)) {
-                nested.push(typeFn)
-            } else {
-                // @Type(() => Foo) — Thunk form. Resolver form (`(data) => Foo`) can't be
-                // evaluated statically and will throw on the no-arg call; we catch and skip.
-                try {
-                    const result = (typeFn as TypeThunk)()
-                    if (isValidatableClass(result)) nested.push(result)
-                } catch {
-                    // Resolver-shaped functions need runtime data; ignore.
-                }
-            }
-
-            // Discriminator subTypes are static — but still guard against malformed entries.
-            const options = fieldMeta.getTypeOptions()
-            if (options?.discriminator) {
-                for (const sub of options.discriminator.subTypes) {
-                    if (isValidatableClass(sub.value)) nested.push(sub.value)
-                }
-            }
-        }
-
-        // @List(Foo) / array element type set by @Type-on-array.
-        const elementType = fieldMeta.getArrayElementType()
-        if (isValidatableClass(elementType)) nested.push(elementType)
-    }
-
-    return nested
-}
-
 const VALIDATED = new WeakSet<ClassConstructor>()
 
 /**
- * Validates a cargo class (and every nested DTO reachable through `@Type` / `@List`)
+ * Validates an analysis result (and every nested DTO within it)
  * against the rule checkers registered in {@link ACTIVE_CHECKERS}.
  *
- * The check runs once per class — subsequent calls for the same class are no-ops,
- * so it's safe to invoke from every `bindingCargo()` call.
- *
  * Throws {@link CargoSchemaError} aggregating every violation found.
- *
- * @example
- * ```ts
- * class CreateUser {
- *      // two source decorators on the same field
- *      @Body()
- *      @Query()
- *      id!: number
- * }
- * validateCargoSchema(CreateUser)     // throws CargoSchemaError
- * ```
  */
-export function validateCargoSchema(cargoClass: ClassConstructor): void {
-    if (VALIDATED.has(cargoClass)) return
+export function validateAnalysis(result: AnalysisResult): void {
+    if (VALIDATED.has(result.rootClass)) return
 
     const violations: RuleViolation[] = []
-    const visited = new Set<ClassConstructor>()
-    const stack: ClassConstructor[] = [cargoClass]
+    const visitedInThisRound: ClassConstructor[] = []
 
-    while (stack.length > 0) {
-        const currentClass = stack.pop() as ClassConstructor
-        if (visited.has(currentClass) || VALIDATED.has(currentClass)) continue
-        visited.add(currentClass)
+    for (const [cls, classMeta] of result.metadataMap) {
+        if (VALIDATED.has(cls)) continue
+        visitedInThisRound.push(cls)
 
-        const classMeta = new CargoClassMetadata(currentClass.prototype, true)
-        const ctx: RuleContext = { cargoClass: currentClass, classMeta }
-
+        const ctx: RuleContext = { cargoClass: cls, classMeta }
         for (const checker of ACTIVE_CHECKERS) {
             violations.push(...checker(ctx))
-        }
-
-        for (const nested of collectNestedClasses(classMeta)) {
-            if (!visited.has(nested) && !VALIDATED.has(nested)) stack.push(nested)
         }
     }
 
     if (violations.length > 0) {
-        throw new CargoSchemaError(cargoClass, violations)
+        throw new CargoSchemaError(result.rootClass, violations)
     }
 
-    // Only on a fully-clean round do we mark classes as validated.
-    // Marking incrementally would let a child with violations be cached as "OK" if its parent happened to finish first.
-    for (const cls of visited) {
+    for (const cls of visitedInThisRound) {
         VALIDATED.add(cls)
     }
 }

--- a/packages/express-cargo/src/types.ts
+++ b/packages/express-cargo/src/types.ts
@@ -209,3 +209,13 @@ export type BindContext = {
     errors: CargoFieldError[]
     sourceKey: string
 }
+
+/**
+ * Result of the class analysis phase.
+ * Contains metadata for the root class and all its nested DTOs.
+ */
+export interface AnalysisResult {
+    rootClass: ClassConstructor
+    rootMeta: CargoClassMetadata
+    metadataMap: Map<ClassConstructor, CargoClassMetadata>
+}

--- a/packages/express-cargo/src/types.ts
+++ b/packages/express-cargo/src/types.ts
@@ -219,3 +219,13 @@ export interface AnalysisResult {
     rootMeta: CargoClassMetadata
     metadataMap: Map<ClassConstructor, CargoClassMetadata>
 }
+
+/**
+ * Merged field lists for a class, precomputed once by {@link CargoClassMetadata.resolve}.
+ */
+export interface ResolvedFieldLists {
+    fields: (string | symbol)[]
+    requestFields: (string | symbol)[]
+    virtualFields: (string | symbol)[]
+    allFields: (string | symbol)[]
+}

--- a/packages/express-cargo/src/utils.ts
+++ b/packages/express-cargo/src/utils.ts
@@ -1,3 +1,5 @@
+import { ClassConstructor } from './types'
+
 /**
  * Determines if a given function is a class constructor.
  * This is a heuristic check to support various transpilation environments (ES6+, Babel, etc.).
@@ -15,6 +17,20 @@ export function isClass(fn: unknown): fn is new (...args: any[]) => any {
     const hasPrototype = fn.prototype && fn.prototype.constructor === fn
     const isPascalCase = fn.name && /^[A-Z]/.test(fn.name)
     return Boolean(isPascalCase && hasPrototype)
+}
+
+// `Object` is included because reflect-metadata falls back to it for unresolvable
+// design:type entries; `Array` guards against a malformed `@List(Array)`.
+// Both pass the isClass heuristic but should never be descended into.
+const PRIMITIVE_TYPES = new Set<unknown>([String, Number, Boolean, Date, Object, Array])
+
+/**
+ * Returns true when a value is a user-defined class worth descending into (a nested DTO),
+ * excluding the built-in constructors that pass the {@link isClass} heuristic but must be
+ * treated as leaves. Shared by schema analysis (traversal) and binding (recursive binding).
+ */
+export function isUserDefinedClass(value: unknown): value is ClassConstructor {
+    return isClass(value) && !PRIMITIVE_TYPES.has(value)
 }
 
 export function isDeepEqual(obj1: any, obj2: any): boolean {

--- a/packages/express-cargo/tests/binding/dynamicPolymorphism.test.ts
+++ b/packages/express-cargo/tests/binding/dynamicPolymorphism.test.ts
@@ -91,24 +91,4 @@ describe('Dynamic Polymorphism Binding', () => {
         expect(err).toBeInstanceOf(Error)
         expect(err.message).toContain('InvalidDTO')
     })
-
-    it('should preserve raw object data when targetClass is Object (e.g. any type)', () => {
-        class AnyDataDTO {
-            @Body('data')
-            data!: any // This will be reflected as Object
-        }
-
-        const middleware = bindingCargo(AnyDataDTO)
-        const rawData = { foo: 'bar', nested: { a: 1 } }
-        const req = makeMockReq({ body: { data: rawData } })
-        const res = makeMockRes()
-        const next = makeNext()
-
-        middleware(req, res, next)
-
-        expect(next).toHaveBeenCalledWith()
-        const dto = getCargo<AnyDataDTO>(req)!
-        // Should be deeply equal to original data, not an empty object
-        expect(dto.data).toEqual(rawData)
-    })
 })

--- a/packages/express-cargo/tests/binding/dynamicPolymorphism.test.ts
+++ b/packages/express-cargo/tests/binding/dynamicPolymorphism.test.ts
@@ -65,4 +65,50 @@ describe('Dynamic Polymorphism Binding', () => {
         expect(dto.data).toBeInstanceOf(DynamicB)
         expect((dto.data as DynamicB).other).toBe(123)
     })
+
+    it('should throw CargoSchemaError if a dynamically resolved class has an invalid schema (Runtime)', () => {
+        class InvalidDTO {
+            @Body('id')
+            @Body('other') // Duplicate source
+            id!: number
+        }
+
+        class DynamicRoot {
+            // Using a Resolver to force runtime analysis
+            @Type((data: any) => (data.kind === 'invalid' ? InvalidDTO : Object))
+            @Body('data')
+            data!: any
+        }
+
+        const middleware = bindingCargo(DynamicRoot)
+        const req = makeMockReq({ body: { data: { kind: 'invalid', id: 1 } } })
+        const res = makeMockRes()
+        const next = makeNext()
+
+        middleware(req, res, next)
+
+        const err = next.mock.calls[0][0]
+        expect(err).toBeInstanceOf(Error)
+        expect(err.message).toContain('InvalidDTO')
+    })
+
+    it('should preserve raw object data when targetClass is Object (e.g. any type)', () => {
+        class AnyDataDTO {
+            @Body('data')
+            data!: any // This will be reflected as Object
+        }
+
+        const middleware = bindingCargo(AnyDataDTO)
+        const rawData = { foo: 'bar', nested: { a: 1 } }
+        const req = makeMockReq({ body: { data: rawData } })
+        const res = makeMockRes()
+        const next = makeNext()
+
+        middleware(req, res, next)
+
+        expect(next).toHaveBeenCalledWith()
+        const dto = getCargo<AnyDataDTO>(req)!
+        // Should be deeply equal to original data, not an empty object
+        expect(dto.data).toEqual(rawData)
+    })
 })

--- a/packages/express-cargo/tests/binding/dynamicPolymorphism.test.ts
+++ b/packages/express-cargo/tests/binding/dynamicPolymorphism.test.ts
@@ -1,0 +1,68 @@
+import { bindingCargo, Body, getCargo, Type } from '../../src'
+import { makeMockReq, makeMockRes, makeNext } from './testUtils'
+
+class NestedDTO {
+    @Body('val') val!: string
+}
+
+class DynamicA {
+    @Type(() => NestedDTO)
+    @Body('nested')
+    nested!: NestedDTO
+}
+
+class DynamicB {
+    @Body('other') other!: number
+}
+
+class RootDTO {
+    // Dynamic Resolver that cannot be analyzed statically
+    @Type((data: any) => (data.kind === 'A' ? DynamicA : DynamicB))
+    @Body('data')
+    data!: DynamicA | DynamicB
+}
+
+describe('Dynamic Polymorphism Binding', () => {
+    it('should correctly bind dynamically resolved classes and their nested fields', () => {
+        const middleware = bindingCargo(RootDTO)
+        const req = makeMockReq({
+            body: {
+                data: {
+                    kind: 'A',
+                    nested: { val: 'hello' },
+                },
+            },
+        })
+        const res = makeMockRes()
+        const next = makeNext()
+
+        middleware(req, res, next)
+
+        expect(next).toHaveBeenCalledWith()
+        const dto = getCargo<RootDTO>(req)!
+        expect(dto.data).toBeInstanceOf(DynamicA)
+        expect((dto.data as DynamicA).nested).toBeInstanceOf(NestedDTO)
+        expect((dto.data as DynamicA).nested.val).toBe('hello')
+    })
+
+    it('should work with type B as well', () => {
+        const middleware = bindingCargo(RootDTO)
+        const req = makeMockReq({
+            body: {
+                data: {
+                    kind: 'B',
+                    other: 123,
+                },
+            },
+        })
+        const res = makeMockRes()
+        const next = makeNext()
+
+        middleware(req, res, next)
+
+        expect(next).toHaveBeenCalledWith()
+        const dto = getCargo<RootDTO>(req)!
+        expect(dto.data).toBeInstanceOf(DynamicB)
+        expect((dto.data as DynamicB).other).toBe(123)
+    })
+})

--- a/packages/express-cargo/tests/binding/sourceBinding.test.ts
+++ b/packages/express-cargo/tests/binding/sourceBinding.test.ts
@@ -78,6 +78,26 @@ describe('source decorator binding', () => {
         expect(dto.nickname).toBeNull()
     })
 
+    it('targetClass가 Object인 경우(any 타입 등) 원본 객체 데이터를 보존함', () => {
+        class AnyDataDTO {
+            @Body('data')
+            data!: any // Object로 리플렉션됨
+        }
+
+        const middleware = bindingCargo(AnyDataDTO)
+        const rawData = { foo: 'bar', nested: { a: 1 } }
+        const req = makeMockReq({ body: { data: rawData } })
+        const res = makeMockRes()
+        const next = makeNext()
+
+        middleware(req, res, next)
+
+        expect(next).toHaveBeenCalledWith()
+        const dto = getCargo<AnyDataDTO>(req)!
+        // 빈 객체 {}가 아닌 원본 데이터와 일치해야 함
+        expect(dto.data).toEqual(rawData)
+    })
+
     it('required source field가 없으면 validator를 건너뛴다', () => {
         const middleware = bindingCargo(TestDTO)
 

--- a/packages/express-cargo/tests/metadata/resolve.test.ts
+++ b/packages/express-cargo/tests/metadata/resolve.test.ts
@@ -1,0 +1,96 @@
+import 'reflect-metadata'
+import { CargoClassMetadata } from '../../src/metadata'
+import { Body } from '../../src'
+import { analyzeCargoSchema } from '../../src/analysis'
+
+describe('CargoClassMetadata.resolve caching', () => {
+    it('caches field lists so post-resolve mutations are not reflected', () => {
+        class Sample {
+            @Body()
+            a!: string
+        }
+
+        const meta = new CargoClassMetadata(Sample.prototype).resolve()
+        const before = meta.getFieldList()
+        expect(before).toEqual(['a'])
+
+        // Add a field directly to the prototype metadata *after* resolve().
+        meta.setFieldList('b')
+
+        // Cached: the resolved snapshot still wins, so 'b' is not visible.
+        expect(meta.getFieldList()).toEqual(['a'])
+    })
+
+    it('walks the prototype chain when not resolved', () => {
+        class Sample {
+            @Body()
+            a!: string
+        }
+
+        const meta = new CargoClassMetadata(Sample.prototype)
+        expect(meta.getFieldList()).toEqual(['a'])
+
+        meta.setFieldList('b')
+
+        // Not cached: a fresh walk reflects the newly added field.
+        expect(meta.getFieldList()).toEqual(expect.arrayContaining(['a', 'b']))
+    })
+
+    it('returns the same array reference across reads after resolve (no recomputation)', () => {
+        class Sample {
+            @Body()
+            a!: string
+
+            @Body()
+            b!: string
+        }
+
+        const meta = new CargoClassMetadata(Sample.prototype).resolve()
+
+        // A walk would build a new array each call; the cache returns the stored reference.
+        expect(meta.getFieldList()).toBe(meta.getFieldList())
+        expect(meta.getRequestFieldList()).toBe(meta.getRequestFieldList())
+        expect(meta.getVirtualFieldList()).toBe(meta.getVirtualFieldList())
+        expect(meta.getAllFieldsList()).toBe(meta.getAllFieldsList())
+    })
+
+    it('resolves every list kind, not just allFields', () => {
+        class Sample {
+            @Body()
+            a!: string
+        }
+
+        const meta = new CargoClassMetadata(Sample.prototype).resolve()
+
+        // Mutate each underlying list after resolve; none should leak through the cache.
+        meta.setFieldList('x')
+        meta.setRequestFieldList('y')
+        meta.setVirtualFieldList('z')
+
+        expect(meta.getFieldList()).not.toContain('x')
+        expect(meta.getRequestFieldList()).not.toContain('y')
+        expect(meta.getVirtualFieldList()).not.toContain('z')
+    })
+
+    it('analyzeCargoSchema produces resolved (cached) metadata', () => {
+        class Nested {
+            @Body()
+            n!: string
+        }
+
+        class Root {
+            @Body()
+            r!: string
+        }
+
+        const result = analyzeCargoSchema(Root)
+        const rootMeta = result.rootMeta
+
+        const snapshot = rootMeta.getFieldList()
+        rootMeta.setFieldList('late')
+
+        // Metadata coming out of analysis must already be resolved/cached.
+        expect(rootMeta.getFieldList()).toEqual(snapshot)
+        expect(rootMeta.getFieldList()).toBe(rootMeta.getFieldList())
+    })
+})

--- a/packages/express-cargo/tests/rules/dynamicValidation.test.ts
+++ b/packages/express-cargo/tests/rules/dynamicValidation.test.ts
@@ -1,0 +1,67 @@
+import { bindingCargo, Body, Query, Type, CargoSchemaError } from '../../src'
+import { makeMockReq, makeMockRes, makeNext } from '../binding/testUtils'
+
+describe('schema validation — dynamic runtime validation', () => {
+    it('런타임에 결정된 클래스가 규칙을 위반하면 CargoSchemaError 발생', () => {
+        class InvalidDynamicDto {
+            @Body()
+            @Query() // 중복 소스 규칙 위반
+            foo!: string
+        }
+
+        class RootDto {
+            @Type((data: any) => (data.kind === 'invalid' ? InvalidDynamicDto : Object))
+            @Body('data')
+            data!: any
+        }
+
+        const middleware = bindingCargo(RootDto)
+
+        // InvalidDynamicDto를 사용하도록 요청
+        const req = makeMockReq({
+            body: {
+                data: { kind: 'invalid', foo: 'bar' },
+            },
+        })
+        const res = makeMockRes()
+        const next = makeNext()
+
+        middleware(req, res, next)
+
+        // validateAnalysis가 에러를 던지고, middleware의 try-catch에서 잡혀 next(err)로 전달됨
+        const err = next.mock.calls[0][0]
+        expect(err).toBeInstanceOf(CargoSchemaError)
+        expect(err.message).toContain('InvalidDynamicDto')
+        expect(err.message).toContain('foo')
+    })
+
+    it('한 번 검증된 동적 클래스는 다음 요청에서 다시 검증하지 않음 (캐시 확인)', () => {
+        // 이 테스트는 기능적으로는 동일하지만, validateAnalysis 내부의 VALIDATED 캐시가 
+        // 오작동하지 않고 정상적으로 다음 바인딩을 허용하는지 확인하는 의미가 있음
+        class ValidDynamicDto {
+            @Body()
+            foo!: string
+        }
+
+        class RootDto {
+            @Type(() => ValidDynamicDto)
+            @Body('data')
+            data!: any
+        }
+
+        const middleware = bindingCargo(RootDto)
+        const res = makeMockRes()
+
+        // 첫 번째 요청: 검증 및 바인딩 성공
+        const req1 = makeMockReq({ body: { data: { foo: 'bar' } } })
+        const next1 = makeNext()
+        middleware(req1, res, next1)
+        expect(next1).toHaveBeenCalledWith()
+
+        // 두 번째 요청: 캐시된 검증 결과 사용 및 바인딩 성공
+        const req2 = makeMockReq({ body: { data: { foo: 'baz' } } })
+        const next2 = makeNext()
+        middleware(req2, res, next2)
+        expect(next2).toHaveBeenCalledWith()
+    })
+})

--- a/packages/express-cargo/tests/rules/eachUsage.test.ts
+++ b/packages/express-cargo/tests/rules/eachUsage.test.ts
@@ -1,6 +1,5 @@
 import { Body, Default, Each, Optional } from '../../src'
-import { validateCargoSchema } from '../../src/rules'
-import { expectViolation } from './testUtils'
+import { expectViolation, validateCargoSchema } from './testUtils'
 
 describe('schema validation — @Each usage rules', () => {
     it('@Each 인자로 Source 데코레이터가 들어가면 거부', () => {

--- a/packages/express-cargo/tests/rules/kindCategory.test.ts
+++ b/packages/express-cargo/tests/rules/kindCategory.test.ts
@@ -1,6 +1,5 @@
 import { Body, Each, Header, List, Min, Optional, Params, Query, Request, Session, Type, Virtual } from '../../src'
-import { validateCargoSchema } from '../../src/rules'
-import { expectViolation } from './testUtils'
+import { expectViolation, validateCargoSchema } from './testUtils'
 
 describe('schema validation — kind category rules', () => {
     it('두 Source 데코레이터 공존 시 거부', () => {

--- a/packages/express-cargo/tests/rules/primitiveSkip.test.ts
+++ b/packages/express-cargo/tests/rules/primitiveSkip.test.ts
@@ -1,5 +1,5 @@
 import { Body, List, Type } from '../../src'
-import { validateCargoSchema } from '../../src/rules'
+import { validateCargoSchema } from './testUtils'
 
 describe('schema validation — primitive constructor skip', () => {
     it('@List(String)같은 프리미티브 element는 nested 검증 대상에서 제외', () => {

--- a/packages/express-cargo/tests/rules/testUtils.ts
+++ b/packages/express-cargo/tests/rules/testUtils.ts
@@ -1,5 +1,16 @@
 import { CargoSchemaError } from '../../src'
+import { analyzeCargoSchema } from '../../src/analysis'
+import { validateAnalysis } from '../../src/rules/validate'
+import { ClassConstructor } from '../../src/types'
 import type { RuleViolation } from '../../src/rules/types'
+
+/**
+ * Test utility to analyze and validate a DTO class in one step.
+ */
+export function validateCargoSchema(cargoClass: ClassConstructor): void {
+    const result = analyzeCargoSchema(cargoClass)
+    validateAnalysis(result)
+}
 
 /**
  * Invokes `fn` and asserts that it throws a `CargoSchemaError` whose `violations`


### PR DESCRIPTION
#224에서 진행된 작업에서 클래스 분석과 검증 로직을 분리하고, 추후 미들웨어에서 분석된 클래스만 사용하여 데이터를 매핑하도록 수정합니다.