### PR TITLE
feat: validate semantic decorator conflict rules

### DIFF
--- a/packages/express-cargo/src/rules/crossField.ts
+++ b/packages/express-cargo/src/rules/crossField.ts
@@ -12,6 +12,14 @@ function unknownReference(state: FieldState, decoratorName: string): string | nu
     return null
 }
 
+function referencesSelf(state: FieldState, decoratorName: string): string | null {
+    for (const applied of state.appliedSelf) {
+        if (applied.name !== decoratorName) continue
+        if (applied.args[0] === state.propertyKey) return String(state.propertyKey)
+    }
+    return null
+}
+
 const withReferencesUnknownField: FieldRuleFn = s => {
     const target = unknownReference(s, With.name)
     return target === null ? null : `@With references unknown field "${target}"`
@@ -22,4 +30,19 @@ const withoutReferencesUnknownField: FieldRuleFn = s => {
     return target === null ? null : `@Without references unknown field "${target}"`
 }
 
-export const CROSS_FIELD_RULES: readonly FieldRuleFn[] = [withReferencesUnknownField, withoutReferencesUnknownField]
+const withReferencesSelf: FieldRuleFn = s => {
+    const target = referencesSelf(s, With.name)
+    return target === null ? null : `@With cannot reference its own field "${String(s.propertyKey)}"`
+}
+
+const withoutReferencesSelf: FieldRuleFn = s => {
+    const target = referencesSelf(s, Without.name)
+    return target === null ? null : `@Without cannot reference its own field "${String(s.propertyKey)}"`
+}
+
+export const CROSS_FIELD_RULES: readonly FieldRuleFn[] = [
+    withReferencesUnknownField,
+    withoutReferencesUnknownField,
+    withReferencesSelf,
+    withoutReferencesSelf,
+]

--- a/packages/express-cargo/src/rules/missingHandler.ts
+++ b/packages/express-cargo/src/rules/missingHandler.ts
@@ -1,10 +1,8 @@
 import { FieldRuleFn } from './types'
 
 const optionalWithDefault: FieldRuleFn = s => {
-    const handlerNames = new Set(s.appliedSelf.filter(d => d.category === 'missing-handler').map(d => d.name))
-    return handlerNames.size > 1
-        ? `${[...handlerNames].map(n => `@${n}`).join(' + ')} cannot be combined; pick a single missing-value strategy`
-        : null
+    const handlers = s.appliedSelf.filter(d => d.category === 'missing-handler')
+    return handlers.length > 1 ? `${handlers.map(d => `@${d.name}`).join(' + ')} cannot be combined; pick a single missing-value strategy` : null
 }
 
 /** Missing-handler duplication rules (`@Optional` / `@Default`). */

--- a/packages/express-cargo/src/rules/missingHandler.ts
+++ b/packages/express-cargo/src/rules/missingHandler.ts
@@ -1,0 +1,11 @@
+import { FieldRuleFn } from './types'
+
+const optionalWithDefault: FieldRuleFn = s => {
+    const handlerNames = new Set(s.appliedSelf.filter(d => d.category === 'missing-handler').map(d => d.name))
+    return handlerNames.size > 1
+        ? `${[...handlerNames].map(n => `@${n}`).join(' + ')} cannot be combined; pick a single missing-value strategy`
+        : null
+}
+
+/** Missing-handler duplication rules (`@Optional` / `@Default`). */
+export const MISSING_HANDLER_RULES: readonly FieldRuleFn[] = [optionalWithDefault]

--- a/packages/express-cargo/src/rules/registry.ts
+++ b/packages/express-cargo/src/rules/registry.ts
@@ -4,6 +4,9 @@ import { BASIC_RULES } from './basic'
 import { KIND_CATEGORY_RULES } from './kindCategory'
 import { EACH_USAGE_RULES } from './eachUsage'
 import { TYPE_HELPER_PLACEMENT_RULES } from './typeHelperPlacement'
+import { TYPE_HELPER_DUPLICATION_RULES } from './typeHelperDuplication'
+import { MISSING_HANDLER_RULES } from './missingHandler'
+import { TRANSFORMER_PRIORITY_RULES } from './transformerPriority'
 import { CROSS_FIELD_RULES } from './crossField'
 
 /** All field-level rule implementations currently active. */
@@ -12,6 +15,9 @@ const FIELD_RULES: readonly FieldRuleFn[] = [
     ...KIND_CATEGORY_RULES,
     ...EACH_USAGE_RULES,
     ...TYPE_HELPER_PLACEMENT_RULES,
+    ...TYPE_HELPER_DUPLICATION_RULES,
+    ...MISSING_HANDLER_RULES,
+    ...TRANSFORMER_PRIORITY_RULES,
     ...CROSS_FIELD_RULES,
 ]
 

--- a/packages/express-cargo/src/rules/transformerPriority.ts
+++ b/packages/express-cargo/src/rules/transformerPriority.ts
@@ -1,0 +1,11 @@
+import { Enum } from '../enum'
+import { FieldRuleFn } from './types'
+
+const enumWithTransform: FieldRuleFn = s => {
+    const hasEnum = s.appliedSelf.some(d => d.name === Enum.name)
+    const hasTransform = s.appliedSelf.some(d => d.category === 'transform')
+    return hasEnum && hasTransform ? `@${Enum.name} cannot be combined with @Transform; @${Enum.name} installs its own transformer` : null
+}
+
+/** Transformer-priority rules — decorators that own their transform reject an extra `@Transform`. */
+export const TRANSFORMER_PRIORITY_RULES: readonly FieldRuleFn[] = [enumWithTransform]

--- a/packages/express-cargo/src/rules/typeHelperDuplication.ts
+++ b/packages/express-cargo/src/rules/typeHelperDuplication.ts
@@ -1,0 +1,9 @@
+import { FieldRuleFn } from './types'
+
+const multipleTypeHelpers: FieldRuleFn = s => {
+    const helpers = s.appliedSelf.filter(d => d.category === 'type-helper')
+    return helpers.length > 1 ? `${helpers.map(d => `@${d.name}`).join(' + ')} cannot be combined; apply a single one of @Type/@List/@Enum` : null
+}
+
+/** Type-helper duplication rules (`@Type` / `@List` / `@Enum`). */
+export const TYPE_HELPER_DUPLICATION_RULES: readonly FieldRuleFn[] = [multipleTypeHelpers]

--- a/packages/express-cargo/tests/rules/crossField.test.ts
+++ b/packages/express-cargo/tests/rules/crossField.test.ts
@@ -22,6 +22,26 @@ describe('schema validation — cross-field reference rules', () => {
         expectViolation(() => validateCargoSchema(WithoutUnknownDto), 'foo', '@Without references unknown field "ghost"')
     })
 
+    it('rejects @With referencing its own field (G3)', () => {
+        class WithSelfDto {
+            @Body()
+            @With('foo')
+            foo!: string
+        }
+
+        expectViolation(() => validateCargoSchema(WithSelfDto), 'foo', '@With cannot reference its own field "foo"')
+    })
+
+    it('rejects @Without referencing its own field (G4)', () => {
+        class WithoutSelfDto {
+            @Body()
+            @Without('foo')
+            foo!: string
+        }
+
+        expectViolation(() => validateCargoSchema(WithoutSelfDto), 'foo', '@Without cannot reference its own field "foo"')
+    })
+
     it('accepts references to existing fields', () => {
         class CrossFieldValidDto {
             @Body()

--- a/packages/express-cargo/tests/rules/missingHandler.test.ts
+++ b/packages/express-cargo/tests/rules/missingHandler.test.ts
@@ -13,6 +13,28 @@ describe('schema validation — missing-handler duplication rules', () => {
         expectViolation(() => validateCargoSchema(OptionalAndDefaultDto), 'foo', 'cannot be combined')
     })
 
+    it('rejects @Default applied twice with conflicting values', () => {
+        class DefaultTwiceDto {
+            @Body()
+            @Default(1)
+            @Default(2)
+            foo!: number
+        }
+
+        expectViolation(() => validateCargoSchema(DefaultTwiceDto), 'foo', '@Default + @Default cannot be combined')
+    })
+
+    it('rejects @Optional applied twice', () => {
+        class OptionalTwiceDto {
+            @Body()
+            @Optional()
+            @Optional()
+            foo!: number
+        }
+
+        expectViolation(() => validateCargoSchema(OptionalTwiceDto), 'foo', '@Optional + @Optional cannot be combined')
+    })
+
     it('accepts @Optional alone', () => {
         class OptionalOnlyDto {
             @Body()

--- a/packages/express-cargo/tests/rules/missingHandler.test.ts
+++ b/packages/express-cargo/tests/rules/missingHandler.test.ts
@@ -1,0 +1,35 @@
+import { Body, Default, Optional } from '../../src'
+import { expectViolation, validateCargoSchema } from './testUtils'
+
+describe('schema validation — missing-handler duplication rules', () => {
+    it('rejects @Optional combined with @Default (C1)', () => {
+        class OptionalAndDefaultDto {
+            @Body()
+            @Optional()
+            @Default(0)
+            foo!: number
+        }
+
+        expectViolation(() => validateCargoSchema(OptionalAndDefaultDto), 'foo', 'cannot be combined')
+    })
+
+    it('accepts @Optional alone', () => {
+        class OptionalOnlyDto {
+            @Body()
+            @Optional()
+            foo!: number
+        }
+
+        expect(() => validateCargoSchema(OptionalOnlyDto)).not.toThrow()
+    })
+
+    it('accepts @Default alone', () => {
+        class DefaultOnlyDto {
+            @Body()
+            @Default(0)
+            foo!: number
+        }
+
+        expect(() => validateCargoSchema(DefaultOnlyDto)).not.toThrow()
+    })
+})

--- a/packages/express-cargo/tests/rules/transformerPriority.test.ts
+++ b/packages/express-cargo/tests/rules/transformerPriority.test.ts
@@ -1,0 +1,40 @@
+import { Body, Enum, Transform } from '../../src'
+import { expectViolation, validateCargoSchema } from './testUtils'
+
+enum Role {
+    ADMIN = 'admin',
+    USER = 'user',
+}
+
+describe('schema validation — transformer-priority rules', () => {
+    it('rejects @Enum combined with @Transform (K3)', () => {
+        class EnumAndTransformDto {
+            @Body()
+            @Enum(Role)
+            @Transform((v: string) => v.toUpperCase())
+            foo!: Role
+        }
+
+        expectViolation(() => validateCargoSchema(EnumAndTransformDto), 'foo', '@Enum cannot be combined with @Transform')
+    })
+
+    it('accepts @Enum without @Transform', () => {
+        class EnumOnlyDto {
+            @Body()
+            @Enum(Role)
+            foo!: Role
+        }
+
+        expect(() => validateCargoSchema(EnumOnlyDto)).not.toThrow()
+    })
+
+    it('accepts @Transform without @Enum', () => {
+        class TransformOnlyDto {
+            @Body()
+            @Transform((v: string) => v.trim())
+            foo!: string
+        }
+
+        expect(() => validateCargoSchema(TransformOnlyDto)).not.toThrow()
+    })
+})

--- a/packages/express-cargo/tests/rules/typeHelperDuplication.test.ts
+++ b/packages/express-cargo/tests/rules/typeHelperDuplication.test.ts
@@ -1,0 +1,68 @@
+import { Body, Enum, List, Type } from '../../src'
+import { expectViolation, validateCargoSchema } from './testUtils'
+
+enum Role {
+    ADMIN = 'admin',
+    USER = 'user',
+}
+
+class Nested {
+    @Body()
+    value!: string
+}
+
+describe('schema validation — type-helper duplication rules', () => {
+    it('rejects @Type combined with @List (F1)', () => {
+        class TypeAndListDto {
+            @Body()
+            @Type(() => Nested)
+            @List(Nested)
+            foo!: Nested[]
+        }
+
+        expectViolation(() => validateCargoSchema(TypeAndListDto), 'foo', 'cannot be combined')
+    })
+
+    it('rejects @Type combined with @Enum (F2)', () => {
+        class TypeAndEnumDto {
+            @Body()
+            @Type(() => Nested)
+            @Enum(Role)
+            foo!: Role
+        }
+
+        expectViolation(() => validateCargoSchema(TypeAndEnumDto), 'foo', 'cannot be combined')
+    })
+
+    it('rejects @List combined with @Enum (F3)', () => {
+        class ListAndEnumDto {
+            @Body()
+            @List(String)
+            @Enum(Role)
+            foo!: string[]
+        }
+
+        expectViolation(() => validateCargoSchema(ListAndEnumDto), 'foo', 'cannot be combined')
+    })
+
+    it('rejects @Type applied twice (F4)', () => {
+        class TypeTwiceDto {
+            @Body()
+            @Type(() => Nested)
+            @Type(() => Nested)
+            foo!: Nested
+        }
+
+        expectViolation(() => validateCargoSchema(TypeTwiceDto), 'foo', 'cannot be combined')
+    })
+
+    it('accepts a single type-helper', () => {
+        class SingleHelperDto {
+            @Body()
+            @Type(() => Nested)
+            foo!: Nested
+        }
+
+        expect(() => validateCargoSchema(SingleHelperDto)).not.toThrow()
+    })
+})


### PR DESCRIPTION
논의에서 결정된 의미적인 충돌 규칙 검증을 추가합니다.
- `@Optional` + `@Default` (값 부재 처리 전략은 하나만)
- `@Type` / `@List` / `@Enum` 중복 (필드당 type-helper 하나만)
- `@With` / `@Without` 자기 자신 참조
- `@Enum` + `@Transform` (Enum이 자체 transformer 보유)