### PR TITLE
feat: reject Each wrapping transform/type-helper decorators

### DIFF
--- a/packages/express-cargo/src/rules/eachUsage.ts
+++ b/packages/express-cargo/src/rules/eachUsage.ts
@@ -12,7 +12,23 @@ const eachWrapsMissingHandler: FieldRuleFn = s => {
     return offenders.length === 0 ? null : `@Each cannot wrap missing-handler decorator(s): ${offenders.map(t => `@${t.name}`).join(', ')}`
 }
 
+const eachWrapsTransform: FieldRuleFn = s => {
+    const offenders = s.appliedEach.filter(t => t.category === 'transform')
+    return offenders.length === 0 ? null : `@Each cannot wrap transform decorator(s): ${offenders.map(t => `@${t.name}`).join(', ')}`
+}
+
+const eachWrapsTypeHelper: FieldRuleFn = s => {
+    const offenders = s.appliedEach.filter(t => t.category === 'type-helper')
+    return offenders.length === 0 ? null : `@Each cannot wrap type-helper decorator(s): ${offenders.map(t => `@${t.name}`).join(', ')}`
+}
+
 const eachOnNonArray: FieldRuleFn = s =>
     s.appliedSelf.some(d => d.name === Each.name) && isKnownNonArray(s.fieldType) ? `@Each can only be applied to array fields` : null
 
-export const EACH_USAGE_RULES: readonly FieldRuleFn[] = [eachWrapsSource, eachWrapsMissingHandler, eachOnNonArray]
+export const EACH_USAGE_RULES: readonly FieldRuleFn[] = [
+    eachWrapsSource,
+    eachWrapsMissingHandler,
+    eachWrapsTransform,
+    eachWrapsTypeHelper,
+    eachOnNonArray,
+]

--- a/packages/express-cargo/tests/rules/eachUsage.test.ts
+++ b/packages/express-cargo/tests/rules/eachUsage.test.ts
@@ -1,4 +1,4 @@
-import { Body, Default, Each, Min, Optional } from '../../src'
+import { Body, Default, Each, Enum, List, Min, Optional, Transform, Type } from '../../src'
 import { expectViolation, validateCargoSchema } from './testUtils'
 
 describe('schema validation — @Each usage rules', () => {
@@ -30,6 +30,51 @@ describe('schema validation — @Each usage rules', () => {
         }
 
         expectViolation(() => validateCargoSchema(EachWrapsDefaultDto), 'foo', '@Each cannot wrap missing-handler decorator')
+    })
+
+    it('rejects @Transform inside @Each', () => {
+        class EachWrapsTransformDto {
+            @Body()
+            @Each(Transform((v: number) => v + 1))
+            foo!: number[]
+        }
+
+        expectViolation(() => validateCargoSchema(EachWrapsTransformDto), 'foo', '@Each cannot wrap transform decorator')
+    })
+
+    it('rejects @List inside @Each', () => {
+        class EachWrapsListDto {
+            @Body()
+            @Each(List('number'))
+            foo!: number[]
+        }
+
+        expectViolation(() => validateCargoSchema(EachWrapsListDto), 'foo', '@Each cannot wrap type-helper decorator')
+    })
+
+    it('rejects @Type inside @Each', () => {
+        class Inner {}
+        class EachWrapsTypeDto {
+            @Body()
+            @Each(Type(() => Inner))
+            foo!: Inner[]
+        }
+
+        expectViolation(() => validateCargoSchema(EachWrapsTypeDto), 'foo', '@Each cannot wrap type-helper decorator')
+    })
+
+    it('rejects @Enum inside @Each', () => {
+        enum Role {
+            ADMIN = 'admin',
+            USER = 'user',
+        }
+        class EachWrapsEnumDto {
+            @Body()
+            @Each(Enum(Role))
+            foo!: Role[]
+        }
+
+        expectViolation(() => validateCargoSchema(EachWrapsEnumDto), 'foo', '@Each cannot wrap type-helper decorator')
     })
 
     it('rejects @Each on a non-array field (H1)', () => {


### PR DESCRIPTION
처음 Each 규칙을 정할 때 source 데코레이터와 default, optional 데코레이터만 거부하는 규칙을 추가하였으나 Each 데코레이터의 의도 자체가 validator를 각 배열의 요소에 적용하기 위함이기 때문이기 때문에 transform, type-helper를 모두 적용하지 못하도록 규칙을 추가합니다.