### PR TITLE
refactor: narrow types.ts to pure type declarations

### DIFF
--- a/packages/express-cargo/src/binding/bind.ts
+++ b/packages/express-cargo/src/binding/bind.ts
@@ -1,5 +1,6 @@
-import { AnalysisResult, BindContext, BindSources, Source, TypeResolver, TypeThunk, TypeOptions } from '../types'
-import { CargoFieldError, CargoTransformFieldError } from '../types'
+import { AnalysisResult, Source, TypeResolver, TypeThunk, TypeOptions } from '../types'
+import { CargoFieldError, CargoTransformFieldError } from '../errors'
+import { BindContext, BindSources } from './types'
 import { CargoClassMetadata, CargoFieldMetadata } from '../metadata'
 import { CargoFile } from '../fileHandler'
 import { validateAnalysis } from '../rules'

--- a/packages/express-cargo/src/binding/fieldHelpers.ts
+++ b/packages/express-cargo/src/binding/fieldHelpers.ts
@@ -1,4 +1,4 @@
-import { CargoFieldError } from '../types'
+import { CargoFieldError } from '../errors'
 import { CargoFieldMetadata } from '../metadata'
 
 export function getErrorKey(sourceKey: string, currentKey: string): string {

--- a/packages/express-cargo/src/binding/middleware.ts
+++ b/packages/express-cargo/src/binding/middleware.ts
@@ -1,6 +1,7 @@
 import type { Request, RequestHandler } from 'express'
 
-import { ClassConstructor, CargoFieldError, CargoValidationError } from '../types'
+import { ClassConstructor } from '../types'
+import { CargoFieldError, CargoValidationError } from '../errors'
 import { getCargoErrorHandler } from '../errorHandler'
 import { getCargoFileLocator } from '../fileHandler'
 import { validateAnalysis } from '../rules'

--- a/packages/express-cargo/src/binding/types.ts
+++ b/packages/express-cargo/src/binding/types.ts
@@ -1,0 +1,23 @@
+import type { Request } from 'express'
+import type { CargoClassMetadata } from '../metadata'
+import type { CargoFieldError } from '../errors'
+
+/** Raw request containers the binder reads field values from. */
+export type BindSources = {
+    req: Request
+    body: any
+    query: any
+    params: any
+    header: any
+    session: any
+    file: any
+}
+
+/** Per-class state threaded through a single binding pass. */
+export type BindContext = {
+    metaClass: CargoClassMetadata
+    targetObject: any
+    sources: BindSources
+    errors: CargoFieldError[]
+    sourceKey: string
+}

--- a/packages/express-cargo/src/decorators/typeHelper.ts
+++ b/packages/express-cargo/src/decorators/typeHelper.ts
@@ -1,5 +1,6 @@
 import { CargoClassMetadata } from '../metadata'
-import { ArrayElementType, cargoErrorMessage, TypedPropertyDecorator, TypeOptions, TypeResolver, TypeThunk, ValidatorRule } from '../types'
+import { ArrayElementType, cargoErrorMessage, TypedPropertyDecorator, TypeOptions, TypeResolver, TypeThunk } from '../types'
+import { ValidatorRule } from '../validatorRule'
 
 const TYPE_MAP = {
     string: String,

--- a/packages/express-cargo/src/decorators/validators/addValidator.ts
+++ b/packages/express-cargo/src/decorators/validators/addValidator.ts
@@ -1,4 +1,5 @@
-import { AppliedDecorator, ValidatorRule } from '../../types'
+import { AppliedDecorator } from '../../types'
+import { ValidatorRule } from '../../validatorRule'
 import { CargoClassMetadata } from '../../metadata'
 
 /**

--- a/packages/express-cargo/src/decorators/validators/array.ts
+++ b/packages/express-cargo/src/decorators/validators/array.ts
@@ -1,4 +1,5 @@
-import { ArrayComparator, cargoErrorMessage, EachValidatorRule, TypedPropertyDecorator, ValidatorRule } from '../../types'
+import { ArrayComparator, cargoErrorMessage, TypedPropertyDecorator } from '../../types'
+import { EachValidatorRule, ValidatorRule } from '../../validatorRule'
 import { CargoClassMetadata } from '../../metadata'
 import { isDeepEqual } from '../../utils'
 import { addValidator } from './addValidator'

--- a/packages/express-cargo/src/decorators/validators/comparison.ts
+++ b/packages/express-cargo/src/decorators/validators/comparison.ts
@@ -1,4 +1,5 @@
-import { cargoErrorMessage, TypedPropertyDecorator, ValidatorRule } from '../../types'
+import { cargoErrorMessage, TypedPropertyDecorator } from '../../types'
+import { ValidatorRule } from '../../validatorRule'
 import { addValidator } from './addValidator'
 
 /**

--- a/packages/express-cargo/src/decorators/validators/crossField.ts
+++ b/packages/express-cargo/src/decorators/validators/crossField.ts
@@ -1,4 +1,5 @@
-import { cargoErrorMessage, ValidatorRule } from '../../types'
+import { cargoErrorMessage } from '../../types'
+import { ValidatorRule } from '../../validatorRule'
 import { addValidator } from './addValidator'
 
 /**

--- a/packages/express-cargo/src/decorators/validators/date.ts
+++ b/packages/express-cargo/src/decorators/validators/date.ts
@@ -1,4 +1,5 @@
-import { cargoErrorMessage, TypedPropertyDecorator, ValidatorRule } from '../../types'
+import { cargoErrorMessage, TypedPropertyDecorator } from '../../types'
+import { ValidatorRule } from '../../validatorRule'
 import { addValidator } from './addValidator'
 
 /**

--- a/packages/express-cargo/src/decorators/validators/number.ts
+++ b/packages/express-cargo/src/decorators/validators/number.ts
@@ -1,4 +1,5 @@
-import { cargoErrorMessage, TypedPropertyDecorator, ValidatorRule } from '../../types'
+import { cargoErrorMessage, TypedPropertyDecorator } from '../../types'
+import { ValidatorRule } from '../../validatorRule'
 import { addValidator } from './addValidator'
 
 /**

--- a/packages/express-cargo/src/decorators/validators/string.ts
+++ b/packages/express-cargo/src/decorators/validators/string.ts
@@ -1,4 +1,5 @@
-import { cargoErrorMessage, HashAlgorithm, IsUrlOptions, TypedPropertyDecorator, UuidVersion, ValidatorRule } from '../../types'
+import { cargoErrorMessage, HashAlgorithm, IsUrlOptions, TypedPropertyDecorator, UuidVersion } from '../../types'
+import { ValidatorRule } from '../../validatorRule'
 import { isValidPhoneNumber, CountryCode } from 'libphonenumber-js'
 import { addValidator } from './addValidator'
 

--- a/packages/express-cargo/src/errorHandler.ts
+++ b/packages/express-cargo/src/errorHandler.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express'
-import { CargoValidationError } from './types'
+import { CargoValidationError } from './errors'
 
 export type CargoErrorHandler = (err: CargoValidationError, req: Request, res: Response, next: NextFunction) => void
 

--- a/packages/express-cargo/src/errors.ts
+++ b/packages/express-cargo/src/errors.ts
@@ -1,0 +1,35 @@
+/**
+ * Represents an error for a specific field validation failure.
+ */
+export class CargoFieldError extends Error {
+    name: string
+    field: string | symbol
+
+    constructor(field: string | symbol, message: string) {
+        super(message)
+        this.name = 'CargoFieldError'
+        this.field = field
+    }
+}
+
+/**
+ * Represents an error when validation fails for a request object.
+ * Contains a list of all field errors.
+ */
+export class CargoValidationError extends Error {
+    name: string
+    errors: CargoFieldError[]
+
+    constructor(errors: CargoFieldError[]) {
+        super('Cargo validation failed')
+        this.name = 'CargoValidationError'
+        this.errors = errors
+    }
+}
+
+export class CargoTransformFieldError extends CargoFieldError {
+    constructor(field: string | symbol, message: string) {
+        super(field, message)
+        this.name = 'CargoTransformFieldError'
+    }
+}

--- a/packages/express-cargo/src/index.ts
+++ b/packages/express-cargo/src/index.ts
@@ -1,6 +1,7 @@
 export * from './decorators'
 export * from './binding'
 export * from './types'
+export * from './errors'
 export * from './errorHandler'
 export * from './fileHandler'
 export { CargoSchemaError } from './rules/errors'

--- a/packages/express-cargo/src/metadata.ts
+++ b/packages/express-cargo/src/metadata.ts
@@ -1,16 +1,17 @@
 import 'reflect-metadata'
 import type { Request } from 'express'
-import {
-    AppliedDecorator,
-    DecoratorScope,
-    ResolvedFieldLists,
-    Source,
-    TypeOptions,
-    TypeResolver,
-    TypeThunk,
-    validArrayElementType,
-    ValidatorRule,
-} from './types'
+import { AppliedDecorator, DecoratorScope, Source, TypeOptions, TypeResolver, TypeThunk, validArrayElementType } from './types'
+import { ValidatorRule } from './validatorRule'
+
+/**
+ * Merged field lists for a class, precomputed once by {@link CargoClassMetadata.resolve}.
+ */
+interface ResolvedFieldLists {
+    fields: (string | symbol)[]
+    requestFields: (string | symbol)[]
+    virtualFields: (string | symbol)[]
+    allFields: (string | symbol)[]
+}
 
 /**
  * Manages metadata for a cargo class.

--- a/packages/express-cargo/src/types.ts
+++ b/packages/express-cargo/src/types.ts
@@ -1,4 +1,3 @@
-import type { Request } from 'express'
 import type { CargoClassMetadata } from './metadata'
 
 /**
@@ -82,102 +81,8 @@ export interface TypeOptions {
  */
 export type ArrayComparator = (expected: any, actual: any) => boolean
 
-type ValidatorFunction = (value: any, instance?: Record<string | symbol, any>) => boolean
 type errorMessageFunction = (property: string | symbol, value: any) => string
 export type cargoErrorMessage = string | errorMessageFunction
-
-/**
- * Represents a validation rule for a property.
- */
-export class ValidatorRule {
-    type: string
-    propertyKey: string | symbol
-    validateFunction: ValidatorFunction
-    message: cargoErrorMessage
-
-    constructor(propertyKey: string | symbol, type: string, validate: ValidatorFunction, message: cargoErrorMessage) {
-        this.propertyKey = propertyKey
-        this.type = type
-        this.validateFunction = validate
-        this.message = message
-    }
-
-    /**
-     * Validates a value against this rule.
-     * @param value - The value to validate.
-     * @param instance - The instance of the object being validated (optional).
-     * @returns A CargoFieldError if validation fails, null otherwise.
-     */
-    validate(value: any, instance?: Record<string | symbol, any>): CargoFieldError | null {
-        if (!this.validateFunction(value, instance)) {
-            const message = typeof this.message === 'string' ? this.message : this.message(this.propertyKey, value)
-            return new CargoFieldError(this.propertyKey, message)
-        }
-
-        return null
-    }
-}
-
-/**
- * Represents a validation rule that applies to each element of an array.
- */
-export class EachValidatorRule extends ValidatorRule {
-    private innerRule: ValidatorRule
-
-    constructor(propertyKey: string | symbol, innerRule: ValidatorRule) {
-        super(propertyKey, 'each', () => true, '')
-        this.innerRule = innerRule
-    }
-
-    validate(value: any, instance?: Record<string | symbol, any>): CargoFieldError | null {
-        if (!Array.isArray(value)) return null
-
-        for (let i = 0; i < value.length; i++) {
-            const item = value[i]
-            const error = this.innerRule.validate(item, instance)
-            if (error) {
-                return new CargoFieldError(`${String(this.propertyKey)}[${i}]`, error.message)
-            }
-        }
-        return null
-    }
-}
-
-/**
- * Represents an error for a specific field validation failure.
- */
-export class CargoFieldError extends Error {
-    name: string
-    field: string | symbol
-
-    constructor(field: string | symbol, message: string) {
-        super(message)
-        this.name = 'CargoFieldError'
-        this.field = field
-    }
-}
-
-/**
- * Represents an error when validation fails for a request object.
- * Contains a list of all field errors.
- */
-export class CargoValidationError extends Error {
-    name: string
-    errors: CargoFieldError[]
-
-    constructor(errors: CargoFieldError[]) {
-        super('Cargo validation failed')
-        this.name = 'CargoValidationError'
-        this.errors = errors
-    }
-}
-
-export class CargoTransformFieldError extends CargoFieldError {
-    constructor(field: string | symbol, message: string) {
-        super(field, message)
-        this.name = 'CargoTransformFieldError'
-    }
-}
 
 export type TypedPropertyDecorator<T> = <K extends string | symbol>(target: { [P in K]?: T }, propertyKey: K) => void
 
@@ -194,24 +99,6 @@ export interface AppliedDecorator {
     args: readonly unknown[]
 }
 
-export type BindSources = {
-    req: Request
-    body: any
-    query: any
-    params: any
-    header: any
-    session: any
-    file: any
-}
-
-export type BindContext = {
-    metaClass: CargoClassMetadata
-    targetObject: any
-    sources: BindSources
-    errors: CargoFieldError[]
-    sourceKey: string
-}
-
 /**
  * Result of the class analysis phase.
  * Contains metadata for the root class and all its nested DTOs.
@@ -220,14 +107,4 @@ export interface AnalysisResult {
     rootClass: ClassConstructor
     rootMeta: CargoClassMetadata
     metadataMap: Map<ClassConstructor, CargoClassMetadata>
-}
-
-/**
- * Merged field lists for a class, precomputed once by {@link CargoClassMetadata.resolve}.
- */
-export interface ResolvedFieldLists {
-    fields: (string | symbol)[]
-    requestFields: (string | symbol)[]
-    virtualFields: (string | symbol)[]
-    allFields: (string | symbol)[]
 }

--- a/packages/express-cargo/src/validatorRule.ts
+++ b/packages/express-cargo/src/validatorRule.ts
@@ -1,0 +1,61 @@
+import { CargoFieldError } from './errors'
+import type { cargoErrorMessage } from './types'
+
+type ValidatorFunction = (value: any, instance?: Record<string | symbol, any>) => boolean
+
+/**
+ * Represents a validation rule for a property.
+ */
+export class ValidatorRule {
+    type: string
+    propertyKey: string | symbol
+    validateFunction: ValidatorFunction
+    message: cargoErrorMessage
+
+    constructor(propertyKey: string | symbol, type: string, validate: ValidatorFunction, message: cargoErrorMessage) {
+        this.propertyKey = propertyKey
+        this.type = type
+        this.validateFunction = validate
+        this.message = message
+    }
+
+    /**
+     * Validates a value against this rule.
+     * @param value - The value to validate.
+     * @param instance - The instance of the object being validated (optional).
+     * @returns A CargoFieldError if validation fails, null otherwise.
+     */
+    validate(value: any, instance?: Record<string | symbol, any>): CargoFieldError | null {
+        if (!this.validateFunction(value, instance)) {
+            const message = typeof this.message === 'string' ? this.message : this.message(this.propertyKey, value)
+            return new CargoFieldError(this.propertyKey, message)
+        }
+
+        return null
+    }
+}
+
+/**
+ * Represents a validation rule that applies to each element of an array.
+ */
+export class EachValidatorRule extends ValidatorRule {
+    private innerRule: ValidatorRule
+
+    constructor(propertyKey: string | symbol, innerRule: ValidatorRule) {
+        super(propertyKey, 'each', () => true, '')
+        this.innerRule = innerRule
+    }
+
+    validate(value: any, instance?: Record<string | symbol, any>): CargoFieldError | null {
+        if (!Array.isArray(value)) return null
+
+        for (let i = 0; i < value.length; i++) {
+            const item = value[i]
+            const error = this.innerRule.validate(item, instance)
+            if (error) {
+                return new CargoFieldError(`${String(this.propertyKey)}[${i}]`, error.message)
+            }
+        }
+        return null
+    }
+}


### PR DESCRIPTION
types의 역할을 좁혀 내부에서 사용하는 타입은 별도의 파일로 분리하고, 사용자가 사용할 수 있는 타입만 export할 수 있도록 수정합니다. 