### PR TITLE
docs: correct decorator casing in README and translated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Add the following settings to your tsconfig.json:
 
 ```ts
 import express from 'express'
-import { Body, bindingCargo, getCargo, min, Header, Params } from 'express-cargo'
+import { Body, bindingCargo, getCargo, Min, Header, Params } from 'express-cargo'
 
 const app = express()
 app.use(express.json())

--- a/apps/docs/docs/examples/nested-request.md
+++ b/apps/docs/docs/examples/nested-request.md
@@ -58,7 +58,7 @@ export class OrderRequest {
 }
 ```
 
-In `UserInfoRequest`, we use the `@header` decorator on the `authorization` property to get the value from the `Authorization` header. Then, the `@transform` decorator extracts just the token value, stripping the `"Bearer "` prefix.
+In `UserInfoRequest`, we use the `@Header` decorator on the `authorization` property to get the value from the `Authorization` header. Then, the `@Transform` decorator extracts just the token value, stripping the `"Bearer "` prefix.
 
 ## 2. Use in an Express Route
 

--- a/apps/docs/i18n/de/docusaurus-plugin-content-docs/current/examples/nested-request.md
+++ b/apps/docs/i18n/de/docusaurus-plugin-content-docs/current/examples/nested-request.md
@@ -57,7 +57,7 @@ export class OrderRequest {
 }
 ```
 
-In `UserInfoRequest` verwenden wir den `@header`-Decorator für die `authorization`-Eigenschaft, um den Wert aus dem `Authorization`-Header zu erhalten. Dann extrahiert der `@transform`-Decorator nur den Token-Wert und entfernt das Präfix `"Bearer "`.
+In `UserInfoRequest` verwenden wir den `@Header`-Decorator für die `authorization`-Eigenschaft, um den Wert aus dem `Authorization`-Header zu erhalten. Dann extrahiert der `@Transform`-Decorator nur den Token-Wert und entfernt das Präfix `"Bearer "`.
 
 ## 2. Verwendung in einer Express-Route
 

--- a/apps/docs/i18n/ja/docusaurus-plugin-content-docs/current/examples/nested-request.md
+++ b/apps/docs/i18n/ja/docusaurus-plugin-content-docs/current/examples/nested-request.md
@@ -57,7 +57,7 @@ export class OrderRequest {
 }
 ```
 
-`UserInfoRequest` では、`authorization` プロパティに `@header` デコレータを使用して `Authorization` ヘッダーから値を取得します。次に、`@transform` デコレータが `"Bearer "` プレフィックスを除去してトークン値のみを抽出します。
+`UserInfoRequest` では、`authorization` プロパティに `@Header` デコレータを使用して `Authorization` ヘッダーから値を取得します。次に、`@Transform` デコレータが `"Bearer "` プレフィックスを除去してトークン値のみを抽出します。
 
 ## 2. Express ルートでの使用
 

--- a/apps/docs/i18n/ko/docusaurus-plugin-content-docs/current/decorators/transforms.md
+++ b/apps/docs/i18n/ko/docusaurus-plugin-content-docs/current/decorators/transforms.md
@@ -63,7 +63,7 @@ http://localhost:3000/search?sortBy=TITLE&count=10
 
 ## 출력 예시
 
-예시 요청 URL로 접근하면, `bindingCargo` 미들웨어가 쿼리 파라미터를 처리합니다. `@transform` 데코레이터는 `sortBy` 값을 소문자 문자열로 정규화하고, `count` 값을 2배로 변환합니다. `getCargo` 함수는 이렇게 변환된 값을 담고 있는 객체를 반환합니다.
+예시 요청 URL로 접근하면, `bindingCargo` 미들웨어가 쿼리 파라미터를 처리합니다. `@Transform` 데코레이터는 `sortBy` 값을 소문자 문자열로 정규화하고, `count` 값을 2배로 변환합니다. `getCargo` 함수는 이렇게 변환된 값을 담고 있는 객체를 반환합니다.
 
 ```json
 {

--- a/apps/docs/i18n/ko/docusaurus-plugin-content-docs/current/examples/nested-request.md
+++ b/apps/docs/i18n/ko/docusaurus-plugin-content-docs/current/examples/nested-request.md
@@ -61,7 +61,7 @@ export class OrderRequest {
 }
 ```
 
-`UserInfoRequest`에서 `@header` 데코레이터를 사용해 `authorization` 속성을 `Authorization` 헤더 값으로 채웁니다. 그 다음, `@transform` 데코레이터로 `"Bearer "` 접두사를 제거하고 토큰 값만 추출합니다.
+`UserInfoRequest`에서 `@Header` 데코레이터를 사용해 `authorization` 속성을 `Authorization` 헤더 값으로 채웁니다. 그 다음, `@Transform` 데코레이터로 `"Bearer "` 접두사를 제거하고 토큰 값만 추출합니다.
 
 ## 2. Express 라우트에서 사용하기
 

--- a/apps/docs/i18n/ru/docusaurus-plugin-content-docs/current/examples/nested-request.md
+++ b/apps/docs/i18n/ru/docusaurus-plugin-content-docs/current/examples/nested-request.md
@@ -57,7 +57,7 @@ export class OrderRequest {
 }
 ```
 
-В `UserInfoRequest` мы используем декоратор `@header` для свойства `authorization`, чтобы получить значение из заголовка `Authorization`. Затем декоратор `@transform` извлекает только значение токена, удаляя префикс `"Bearer "`.
+В `UserInfoRequest` мы используем декоратор `@Header` для свойства `authorization`, чтобы получить значение из заголовка `Authorization`. Затем декоратор `@Transform` извлекает только значение токена, удаляя префикс `"Bearer "`.
 
 ## 2. Использование в маршруте Express
 

--- a/apps/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/examples/nested-request.md
+++ b/apps/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/examples/nested-request.md
@@ -58,7 +58,7 @@ export class OrderRequest {
 }
 ```
 
-在 `UserInfoRequest` 中，我们在 `authorization` 属性上使用 `@header` 装饰器，从 `Authorization` header 获取值。然后，`@transform` 装饰器只提取 token 值，并移除 `"Bearer "` 前缀。
+在 `UserInfoRequest` 中，我们在 `authorization` 属性上使用 `@Header` 装饰器，从 `Authorization` header 获取值。然后，`@Transform` 装饰器只提取 token 值，并移除 `"Bearer "` 前缀。
 
 ## 2. 在 Express 路由中使用
 

--- a/apps/example/src/routers/transform.ts
+++ b/apps/example/src/routers/transform.ts
@@ -34,7 +34,7 @@ router.post('/request', bindingCargo(RequestExample), (req, res) => {
     const cargo = getCargo<RequestExample>(req)
 
     res.json({
-        message: 'Header data mapped using @request',
+        message: 'Header data mapped using @Request',
         data: cargo,
     })
 })
@@ -53,7 +53,7 @@ class VirtualExample {
 router.post('/virtual', bindingCargo(VirtualExample), (req, res) => {
     const cargo = getCargo<VirtualExample>(req)
     res.json({
-        message: 'Order data processed with @virtual',
+        message: 'Order data processed with @Virtual',
         data: cargo,
     })
 })


### PR DESCRIPTION
문서에 이전 변경사항인 모든 데코레이터 이름을 대문자로 바꿀 때 변경되지 않은 부분이 발견되어 오탈자를 수정합니다. 