### PR TITLE
refactor: stop exporting internal types from the package barrel

### DIFF
--- a/packages/express-cargo/src/index.ts
+++ b/packages/express-cargo/src/index.ts
@@ -1,7 +1,23 @@
+// Public modules
 export * from './decorators'
 export * from './binding'
-export * from './types'
 export * from './errors'
 export * from './errorHandler'
 export * from './fileHandler'
-export { CargoSchemaError } from './rules/errors'
+export * from './rules/errors'
+
+// `types.ts` is mixed: everything omitted here is internal and may change without notice.
+export type {
+    ClassConstructor,
+    ArrayElementType,
+    ArrayComparator,
+    CargoErrorMessage,
+    TypedPropertyDecorator,
+    TypeThunk,
+    TypeResolver,
+    TypeOptions,
+    DiscriminatorOptions,
+    UuidVersion,
+    HashAlgorithm,
+    IsUrlOptions,
+} from './types'


### PR DESCRIPTION
내부 internal type이 barrel export로 인해 export 되고 있어 이를 수정하여 외부에서 사용자가 직접 인스턴스를 만들거나, 타입을 추론하는데 사용할 수 있는 타입만 export 하도록 수정합니다.