### PR TITLE
test: implement missing test cases

### DIFF
--- a/packages/express-cargo/src/decorators/validators/string.ts
+++ b/packages/express-cargo/src/decorators/validators/string.ts
@@ -158,7 +158,7 @@ export function Email(message?: CargoErrorMessage): TypedPropertyDecorator<strin
                 propertyKey,
                 'email',
                 (value: unknown) => typeof value === 'string' && DEFAULT_EMAIL_PATTERN.test(value),
-                message || `${String(propertyKey)} should be email format`,
+                message || `${String(propertyKey)} should be a valid email`,
             ),
         )
     }

--- a/packages/express-cargo/tests/binding/transformFieldError.test.ts
+++ b/packages/express-cargo/tests/binding/transformFieldError.test.ts
@@ -1,0 +1,119 @@
+import { bindingCargo, Body, Request, Virtual, Transform, CargoFieldError, CargoTransformFieldError, CargoValidationError } from '../../src'
+import { makeMockReq, makeMockRes, makeNext } from './testUtils'
+
+/** Runs the middleware and returns the error handed to next(). */
+function bindAndCatch(cargoClass: any) {
+    const req = makeMockReq({ body: { name: 'alice' }, headers: {} })
+    const res = makeMockRes()
+    const next = makeNext()
+
+    bindingCargo(cargoClass)(req, res, next)
+
+    return next.mock.calls[0][0]
+}
+
+describe('transform field error binding', () => {
+    it('wraps a throwing request transformer in CargoTransformFieldError', () => {
+        class ThrowingRequestDTO {
+            @Request(() => {
+                throw new Error('header lookup failed')
+            })
+            userId!: string
+        }
+
+        const error = bindAndCatch(ThrowingRequestDTO)
+
+        expect(error).toBeInstanceOf(CargoValidationError)
+        const fieldError = error.errors[0]
+        expect(fieldError).toBeInstanceOf(CargoTransformFieldError)
+        expect(fieldError.name).toBe('CargoTransformFieldError')
+        expect(fieldError.field).toBe('userId')
+        expect(fieldError.message).toBe('Error while computing request transform field: header lookup failed')
+    })
+
+    it('wraps a throwing virtual transformer in CargoTransformFieldError', () => {
+        class ThrowingVirtualDTO {
+            @Body('name') name!: string
+
+            @Virtual(() => {
+                throw new Error('cannot compute')
+            })
+            label!: string
+        }
+
+        const error = bindAndCatch(ThrowingVirtualDTO)
+
+        const fieldError = error.errors[0]
+        expect(fieldError).toBeInstanceOf(CargoTransformFieldError)
+        expect(fieldError.field).toBe('label')
+        expect(fieldError.message).toBe('Error while computing virtual field: cannot compute')
+    })
+
+    it('stringifies a thrown non-Error value', () => {
+        class ThrowingStringDTO {
+            @Request(() => {
+                throw 'plain string'
+            })
+            userId!: string
+        }
+
+        const error = bindAndCatch(ThrowingStringDTO)
+
+        expect(error.errors[0].message).toBe('Error while computing request transform field: plain string')
+    })
+
+    it('extends CargoFieldError so a generic error handler still sees it', () => {
+        class ThrowingRequestDTO {
+            @Request(() => {
+                throw new Error('boom')
+            })
+            userId!: string
+        }
+
+        const error = bindAndCatch(ThrowingRequestDTO)
+
+        expect(error.errors[0]).toBeInstanceOf(CargoFieldError)
+        expect(error.errors[0]).toBeInstanceOf(Error)
+    })
+
+    it('keeps binding the remaining fields after a transformer throws', () => {
+        class PartialFailureDTO {
+            @Request(() => {
+                throw new Error('boom')
+            })
+            userId!: string
+
+            @Body('missing') missing!: string
+
+            @Virtual(() => {
+                throw new Error('another boom')
+            })
+            label!: string
+        }
+
+        const error = bindAndCatch(PartialFailureDTO)
+
+        // Request fields bind first, then sources, then virtuals — every phase runs even after one throws.
+        expect(error.errors.map((e: CargoValidationError['errors'][number]) => e.message)).toEqual([
+            'Error while computing request transform field: boom',
+            'missing is required',
+            'Error while computing virtual field: another boom',
+        ])
+    })
+
+    it('does not wrap a throwing @Transform transformer', () => {
+        class ThrowingTransformDTO {
+            @Body('name')
+            @Transform(() => {
+                throw new Error('trim failed')
+            })
+            name!: string
+        }
+
+        const error = bindAndCatch(ThrowingTransformDTO)
+
+        // transformSource() runs outside the try/catch, so the raw error reaches next() untouched.
+        expect(error).not.toBeInstanceOf(CargoValidationError)
+        expect(error).toEqual(new Error('trim failed'))
+    })
+})

--- a/packages/express-cargo/tests/decorators/validators/string/email.test.ts
+++ b/packages/express-cargo/tests/decorators/validators/string/email.test.ts
@@ -1,0 +1,82 @@
+import { CargoFieldError, Email } from '../../../../src'
+import { CargoClassMetadata } from '../../../../src/metadata'
+
+describe('@Email decorator', () => {
+    class Sample {
+        @Email()
+        email!: string
+
+        noValidatorValue!: string
+    }
+
+    const classMeta = new CargoClassMetadata(Sample.prototype)
+    const meta = classMeta.getFieldMetadata('email')
+    const emailRule = meta.getValidators()?.find(v => v.type === 'email')
+
+    it('should have email validator', () => {
+        expect(emailRule).toBeDefined()
+        expect(emailRule?.message).toBe('email should be a valid email')
+    })
+
+    it('should pass for valid email addresses', () => {
+        expect(emailRule?.validate('user@example.com')).toBeNull()
+        expect(emailRule?.validate('first.last+tag@sub.example.co.kr')).toBeNull()
+        expect(emailRule?.validate("o'brien!#$%&*+-/=?^_`{|}~@example.com")).toBeNull()
+        expect(emailRule?.validate('USER@EXAMPLE.COM')).toBeNull()
+    })
+
+    it('should pass for a host without a dot', () => {
+        // The dotted part of the domain is optional, so intranet hosts are accepted.
+        expect(emailRule?.validate('user@localhost')).toBeNull()
+    })
+
+    it('should fail for malformed addresses', () => {
+        expect(emailRule?.validate('plainaddress')).toBeInstanceOf(CargoFieldError)
+        expect(emailRule?.validate('user@')).toBeInstanceOf(CargoFieldError)
+        expect(emailRule?.validate('@example.com')).toBeInstanceOf(CargoFieldError)
+        expect(emailRule?.validate('user@@example.com')).toBeInstanceOf(CargoFieldError)
+        expect(emailRule?.validate('user@example..com')).toBeInstanceOf(CargoFieldError)
+        expect(emailRule?.validate('')).toBeInstanceOf(CargoFieldError)
+    })
+
+    it('should fail when a domain label starts or ends with a hyphen', () => {
+        expect(emailRule?.validate('user@-example.com')).toBeInstanceOf(CargoFieldError)
+        expect(emailRule?.validate('user@example-.com')).toBeInstanceOf(CargoFieldError)
+    })
+
+    it('should fail for addresses containing whitespace', () => {
+        expect(emailRule?.validate('user name@example.com')).toBeInstanceOf(CargoFieldError)
+        expect(emailRule?.validate('user@exam ple.com')).toBeInstanceOf(CargoFieldError)
+        expect(emailRule?.validate('user@example.com ')).toBeInstanceOf(CargoFieldError)
+    })
+
+    it('should fail for non-string values', () => {
+        expect(emailRule?.validate(null)).toBeInstanceOf(CargoFieldError)
+        expect(emailRule?.validate(undefined)).toBeInstanceOf(CargoFieldError)
+        expect(emailRule?.validate(123)).toBeInstanceOf(CargoFieldError)
+    })
+
+    it('should not have email validator on undecorated field', () => {
+        const meta = classMeta.getFieldMetadata('noValidatorValue')
+        const rule = meta.getValidators()?.find(v => v.type === 'email')
+
+        expect(rule).toBeUndefined()
+    })
+
+    it('should support custom error message', () => {
+        class CustomMessage {
+            @Email('custom error')
+            value!: string
+        }
+
+        const customMeta = new CargoClassMetadata(CustomMessage.prototype)
+        const rule = customMeta
+            .getFieldMetadata('value')
+            .getValidators()
+            ?.find(v => v.type === 'email')
+
+        const error = rule?.validate('plainaddress')
+        expect(error).toBeInstanceOf(CargoFieldError)
+        expect(error?.message).toBe('custom error')
+    })
+})

--- a/packages/express-cargo/tests/errorHandler.test.ts
+++ b/packages/express-cargo/tests/errorHandler.test.ts
@@ -1,0 +1,105 @@
+import { bindingCargo, Body, Min, Transform, CargoValidationError, CargoErrorHandler, setCargoErrorHandler, getCargoErrorHandler } from '../src'
+import { makeMockReq, makeMockRes, makeNext } from './binding/testUtils'
+
+class ScoreDTO {
+    @Body('score')
+    @Min(10)
+    score!: number
+}
+
+describe('cargo error handler', () => {
+    const defaultHandler = getCargoErrorHandler()!
+
+    afterEach(() => {
+        // Restore the default handler so custom-handler tests don't leak.
+        setCargoErrorHandler(defaultHandler)
+    })
+
+    it('forwards the validation error to next by default', () => {
+        const req = makeMockReq({ body: { score: 1 } })
+        const res = makeMockRes()
+        const next = makeNext()
+
+        bindingCargo(ScoreDTO)(req, res, next)
+
+        expect(next).toHaveBeenCalledTimes(1)
+        expect(next.mock.calls[0][0]).toBeInstanceOf(CargoValidationError)
+    })
+
+    it('returns the handler that was registered last', () => {
+        const handler: CargoErrorHandler = () => {}
+        setCargoErrorHandler(handler)
+
+        expect(getCargoErrorHandler()).toBe(handler)
+    })
+
+    it('invokes the registered handler instead of next when validation fails', () => {
+        const handler = jest.fn()
+        setCargoErrorHandler(handler)
+
+        const req = makeMockReq({ body: { score: 1 } })
+        const res = makeMockRes()
+        const next = makeNext()
+
+        bindingCargo(ScoreDTO)(req, res, next)
+
+        expect(next).not.toHaveBeenCalled()
+        expect(handler).toHaveBeenCalledTimes(1)
+
+        const [err, handlerReq, handlerRes, handlerNext] = handler.mock.calls[0]
+        expect(err).toBeInstanceOf(CargoValidationError)
+        expect(err.errors.map((e: CargoValidationError['errors'][number]) => e.message)).toContain('score must be >= 10')
+        expect(handlerReq).toBe(req)
+        expect(handlerRes).toBe(res)
+        expect(handlerNext).toBe(next)
+    })
+
+    it('falls through to the express error middleware when the handler calls next', () => {
+        setCargoErrorHandler((err, req, res, next) => next(err))
+
+        const req = makeMockReq({ body: { score: 1 } })
+        const res = makeMockRes()
+        const next = makeNext()
+
+        bindingCargo(ScoreDTO)(req, res, next)
+
+        expect(next).toHaveBeenCalledTimes(1)
+        expect(next.mock.calls[0][0]).toBeInstanceOf(CargoValidationError)
+    })
+
+    it('does not invoke the handler when binding succeeds', () => {
+        const handler = jest.fn()
+        setCargoErrorHandler(handler)
+
+        const req = makeMockReq({ body: { score: 42 } })
+        const res = makeMockRes()
+        const next = makeNext()
+
+        bindingCargo(ScoreDTO)(req, res, next)
+
+        expect(handler).not.toHaveBeenCalled()
+        expect(next).toHaveBeenCalledWith()
+    })
+
+    it('does not invoke the handler for errors other than CargoValidationError', () => {
+        class ThrowingTransformDTO {
+            @Body('name')
+            @Transform(() => {
+                throw new Error('transform blew up')
+            })
+            name!: string
+        }
+
+        const handler = jest.fn()
+        setCargoErrorHandler(handler)
+
+        const req = makeMockReq({ body: { name: 'alice' } })
+        const res = makeMockRes()
+        const next = makeNext()
+
+        bindingCargo(ThrowingTransformDTO)(req, res, next)
+
+        expect(handler).not.toHaveBeenCalled()
+        expect(next.mock.calls[0][0]).toEqual(new Error('transform blew up'))
+    })
+})


### PR DESCRIPTION
누락된 테스트 3종 코드를 추가합니다. `@Email`, `set/getCargoErrorHandler`, `CargoTransformFieldError`에 대해 테스트 코드를 추가하였습니다. 테스트 코드 추가 도중 기존 `@Email` 기본 오류 메시지가 기존 다른 메시지와 통합되지 않고, 문서와도 맞지 않는 것을 발견해 문서와 일치하도록 수정하였습니다.